### PR TITLE
fix namespacing in proxy functions for shiny apps with modules

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -12,6 +12,12 @@ mapboxgl_proxy <- function(mapId, session = shiny::getDefaultReactiveDomain()) {
     stop("mapboxgl_proxy must be called from within a Shiny session")
   }
 
+  if (!is.null(session$ns) &&
+    nzchar(session$ns(NULL)) &&
+    substring(mapId, 1, nchar(session$ns(""))) != session$ns("")) {
+    mapId <- session$ns(mapId)
+  }
+
   proxy <- list(id = mapId, session = session)
   class(proxy) <- "mapboxgl_proxy"
   proxy
@@ -29,6 +35,12 @@ mapboxgl_proxy <- function(mapId, session = shiny::getDefaultReactiveDomain()) {
 maplibre_proxy <- function(mapId, session = shiny::getDefaultReactiveDomain()) {
   if (is.null(session)) {
     stop("maplibre_proxy must be called from within a Shiny session")
+  }
+
+  if (!is.null(session$ns) &&
+    nzchar(session$ns(NULL)) &&
+    substring(mapId, 1, nchar(session$ns(""))) != session$ns("")) {
+    mapId <- session$ns(mapId)
   }
 
   proxy <- list(id = mapId, session = session)


### PR DESCRIPTION
Hi @walkerke,

This PR addresses the first problem encountered and discussed in #12 - that there is a namespacing issue when using the `mapgl_proxy()` or `maplibre_proxy()` functions in a modularised shiny app. This was first problematic when changes would not occur on the map when trying the `set_filter()` via `mapgl_proxy()` on this [test app](https://github.com/RWParsons/test-app/tree/main).

It passes a `devtools::check()` but I'm not sure how thorough this is of a check as there isn't currently a testing suite.

Cheers,
Rex