### PR TITLE
adapted @stefanlinner's code to make set_tooltips/source work on maplibre side

### DIFF
--- a/inst/htmlwidgets/maplibregl.js
+++ b/inst/htmlwidgets/maplibregl.js
@@ -1,3 +1,28 @@
+function onMouseMoveTooltip(e, map, tooltipPopup, tooltipProperty) {
+  map.getCanvas().style.cursor = "pointer";
+  if (e.features.length > 0) {
+    const description = e.features[0].properties[tooltipProperty];
+    tooltipPopup.setLngLat(e.lngLat).setHTML(description).addTo(map);
+
+    // Store reference to currently active tooltip
+    window._activeTooltip = tooltipPopup;
+  } else {
+    tooltipPopup.remove();
+    // If this was the active tooltip, clear the reference
+    if (window._activeTooltip === tooltipPopup) {
+      delete window._activeTooltip;
+    }
+  }
+}
+
+function onMouseLeaveTooltip(map, tooltipPopup) {
+  map.getCanvas().style.cursor = "";
+  tooltipPopup.remove();
+  if (window._activeTooltip === tooltipPopup) {
+    delete window._activeTooltip;
+  }
+}
+
 HTMLWidgets.widget({
     name: "maplibregl",
 
@@ -288,28 +313,30 @@ HTMLWidgets.widget({
                                         closeOnClick: false,
                                     });
 
-                                    map.on("mousemove", layer.id, function (e) {
-                                        map.getCanvas().style.cursor =
-                                            "pointer";
+                                    // Create a reference to the mousemove handler function.
+                                    // We need to pass 'e', 'map', 'tooltip', and 'layer.tooltip' to onMouseMoveTooltip.
+                                    const mouseMoveHandler = function(e) {
+                                        onMouseMoveTooltip(e, map, tooltip, layer.tooltip);
+                                    };
 
-                                        if (e.features.length > 0) {
-                                            const description =
-                                                e.features[0].properties[
-                                                    layer.tooltip
-                                                ];
-                                            tooltip
-                                                .setLngLat(e.lngLat)
-                                                .setHTML(description)
-                                                .addTo(map);
-                                        } else {
-                                            tooltip.remove();
-                                        }
-                                    });
+                                    // Create a reference to the mouseleave handler function.
+                                    // We need to pass 'map' and 'tooltip' to onMouseLeaveTooltip.
+                                    const mouseLeaveHandler = function() {
+                                        onMouseLeaveTooltip(map, tooltip);
+                                    };
 
-                                    map.on("mouseleave", layer.id, function () {
-                                        map.getCanvas().style.cursor = "";
-                                        tooltip.remove();
-                                    });
+                                    // Attach the named handler references, not anonymous functions.
+                                    map.on("mousemove", layer.id, mouseMoveHandler);
+                                    map.on("mouseleave", layer.id, mouseLeaveHandler);
+
+                                    // Store these handler references so you can remove them later if needed
+                                    if (!window._mapboxHandlers) {
+                                        window._mapboxHandlers = {};
+                                    }
+                                    window._mapboxHandlers[layer.id] = {
+                                        mousemove: mouseMoveHandler,
+                                        mouseleave: mouseLeaveHandler
+                                    };
                                 }
 
                                 // Add hover effect if provided
@@ -1053,27 +1080,27 @@ if (HTMLWidgets.shinyMode) {
                             closeOnClick: false,
                         });
 
-                        map.on("mousemove", message.layer.id, function (e) {
-                            map.getCanvas().style.cursor = "pointer";
+                        // Define named handler functions:
+                        const mouseMoveHandler = function(e) {
+                            onMouseMoveTooltip(e, map, tooltip, message.layer.tooltip);
+                        };
 
-                            if (e.features.length > 0) {
-                                const description =
-                                    e.features[0].properties[
-                                        message.layer.tooltip
-                                    ];
-                                tooltip
-                                    .setLngLat(e.lngLat)
-                                    .setHTML(description)
-                                    .addTo(map);
-                            } else {
-                                tooltip.remove();
-                            }
-                        });
+                        const mouseLeaveHandler = function() {
+                            onMouseLeaveTooltip(map, tooltip);
+                        };
 
-                        map.on("mouseleave", message.layer.id, function () {
-                            map.getCanvas().style.cursor = "";
-                            tooltip.remove();
-                        });
+                        // Attach handlers by reference:
+                        map.on("mousemove", message.layer.id, mouseMoveHandler);
+                        map.on("mouseleave", message.layer.id, mouseLeaveHandler);
+
+                        // Store these handler references for later removal:
+                        if (!window._mapboxHandlers) {
+                            window._mapboxHandlers = {};
+                        }
+                        window._mapboxHandlers[message.layer.id] = {
+                            mousemove: mouseMoveHandler,
+                            mouseleave: mouseLeaveHandler
+                        };
                     }
 
                     // Add hover effect if provided
@@ -1155,7 +1182,24 @@ if (HTMLWidgets.shinyMode) {
                     );
                 }
             } else if (message.type === "remove_layer") {
+                            // If there's an active tooltip, remove it first
+                if (window._activeTooltip) {
+                  window._activeTooltip.remove();
+                  delete window._activeTooltip;
+                }
                 if (map.getLayer(message.layer)) {
+                                      // Check if we have stored handlers for this layer
+                    if (window._mapboxHandlers && window._mapboxHandlers[message.layer]) {
+                        const handlers = window._mapboxHandlers[message.layer];
+                        if (handlers.mousemove) {
+                            map.off("mousemove", message.layer, handlers.mousemove);
+                        }
+                        if (handlers.mouseleave) {
+                            map.off("mouseleave", message.layer, handlers.mouseleave);
+                        }
+                        // Clean up the reference
+                        delete window._mapboxHandlers[message.layer];
+                    }
                     map.removeLayer(message.layer);
                 }
                 if (map.getSource(message.layer)) {
@@ -1731,6 +1775,74 @@ if (HTMLWidgets.shinyMode) {
                 } else {
                     console.error("Invalid image data:", message);
                 }
+            } else if (message.type === "set_tooltip") {
+                const layerId = message.layer;
+                const newTooltipProperty = message.tooltip;
+
+                // If there's an active tooltip open, remove it first
+                if (window._activeTooltip) {
+                  window._activeTooltip.remove();
+                  delete window._activeTooltip;
+                }
+
+                // Remove old handlers if any
+                if (window._mapboxHandlers && window._mapboxHandlers[layerId]) {
+                  const handlers = window._mapboxHandlers[layerId];
+                  if (handlers.mousemove) {
+                    map.off("mousemove", layerId, handlers.mousemove);
+                  }
+                  if (handlers.mouseleave) {
+                    map.off("mouseleave", layerId, handlers.mouseleave);
+                  }
+                  delete window._mapboxHandlers[layerId];
+                }
+
+                // Create a new tooltip popup
+                const tooltip = new maplibregl.Popup({
+                  closeButton: false,
+                  closeOnClick: false,
+                });
+
+                // Define new handlers referencing the updated tooltip property
+                const mouseMoveHandler = function(e) {
+                  onMouseMoveTooltip(e, map, tooltip, newTooltipProperty);
+                };
+                const mouseLeaveHandler = function() {
+                  onMouseLeaveTooltip(map, tooltip);
+                };
+
+                // Add the new event handlers
+                map.on("mousemove", layerId, mouseMoveHandler);
+                map.on("mouseleave", layerId, mouseLeaveHandler);
+
+                // Store these handlers so we can remove/update them in the future
+                if (!window._mapboxHandlers) {
+                  window._mapboxHandlers = {};
+                }
+                window._mapboxHandlers[layerId] = {
+                  mousemove: mouseMoveHandler,
+                  mouseleave: mouseLeaveHandler
+                };
+          } else if (message.type === "set_source") {
+              const layerId = message.layer;
+              const newData = message.source;
+              const layerObject = map.getLayer(layerId);
+
+              if (!layerObject) {
+                console.error("Layer not found: ", layerId);
+                return;
+              }
+
+              const sourceId = layerObject.source;
+              const sourceObject = map.getSource(sourceId);
+
+              if (!sourceObject) {
+                console.error("Source not found: ", sourceId);
+                return;
+              }
+
+              // Update the geojson data
+              sourceObject.setData(newData);
             }
         }
     });


### PR DESCRIPTION
At title says, i adapted @stefanlinner's code to make set_tooltips/source work on maplibre side. (issue #42) 

i'm pretty extremely new to JS but functions are tested in a minimal shiny app:

`
library(mapgl)
library(sf)
library(shiny)
library(dplyr)

nc <- st_read(system.file("shape/nc.shp", package="sf")) %>%
  mutate(label = paste0(NAME, "<br>", AREA, "<br>", PERIMETER)) |>
  mutate(FIPS = as.numeric(FIPS))

maplibre.ui <-
  fluidPage(

    actionButton("clear.and.refill", "Click")
    ,checkboxInput("arbitrary.filter", "arbitrary.filter")

    ,shiny::selectizeInput("tooltip.colm", label = "tooltip column"
                           ,choices = colnames(nc)[c(1:14,16)]
                           ,selected  = "label"
    )

    ,checkboxInput("arbitrary.filter.source", "arbitrary.filter by source")

    ,maplibreOutput("map")
  )

maplibre.server <- function(input, output, session) {

  output$map <-
    renderMaplibre({

      maplibre() %>%
        fit_bounds(
          nc,
          animate = FALSE
        ) |>
        add_fill_layer(
          "fill",
          source = nc,
          fill_color = interpolate(
            column = "AREA",
            values = c(min(nc[["AREA"]]), max(nc[["AREA"]])),
            stops = c("#f7fbff", "#08306b"),
            na_color = "lightgrey"
          )
          ,tooltip = "label"
        )
    })

  proxy <- maplibre_proxy("map", session)

  # clear and refill a bunch of times
  observeEvent(input$clear.and.refill, {

    for(i in 1:200){
      proxy |>
        clear_layer("fill") |>
        add_fill_layer(
          "fill",
          source = nc,
          fill_color = interpolate(
            column = "AREA",
            values = c(min(nc[["AREA"]]), max(nc[["AREA"]])),
            stops = c("#f7fbff", "#08306b"),
            na_color = "lightgrey"
          )
        )
    }

  })

  # arbitrary filter by changing source data
  observeEvent( input$arbitrary.filter.source, {

    if(input$arbitrary.filter.source) {
      x <- nc |>
        filter(FIPS >= 37100)
    } else{
      x <- nc
    }

    proxy |>
      mapgl::set_source("fill", x)
  })

  # arbitrary filter by mapgl::set_filter
  observeEvent( input$arbitrary.filter, {

    if(input$arbitrary.filter)
      proxy |>
      mapgl::set_filter(
        layer_id = "fill"
        ,filter =
          list(">=", get_column("FIPS"), 37100)
      )
    else
      proxy |>
      mapgl::set_filter(
        layer_id = "fill"
        ,filter =
          list(">=", get_column("FIPS"), 0)
      )

  })

  # do tooltip by column.
  observeEvent( input$tooltip.colm, {
    req(proxy)

    proxy |>
      mapgl::set_tooltip(
        "fill"
        ,input$tooltip.colm
      )
  })
}

shinyApp(
  ui = maplibre.ui,
  server = maplibre.server
)
`
