### PR TITLE
Add gh link to DESCRIPTION + add search bar to pkgdown site

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,7 @@ Description: Provides an interface to the 'Mapbox GL JS' (<https://docs.mapbox.c
     filled maps, circle maps, 'heatmaps', and three-dimensional graphics; and customize map styles and views.  The package
     also includes utilities to use 'Mapbox' and 'MapLibre' maps in 'Shiny' web applications.
 URL: https://walker-data.com/mapgl/
+BugReports: https://github.com/walkerke/mapgl/issues
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -18,7 +18,6 @@ navbar:
     - reference
     - articles
     - news
-    right: github
   components:
     home:
       icon: fa-home fa-lg
@@ -37,7 +36,3 @@ navbar:
         href: articles/map-design.html
       - text: Using mapgl with Shiny
         href: articles/margins-of-error.html
-
-    github:
-      icon: fa-github fa-lg
-      href: https://github.com/walkerke/mapgl


### PR DESCRIPTION
for discoverability https://blog.r-hub.io/2019/12/10/urls/

The link to GitHub will be kept once `pkgdown::build_site()` is called again.

The github icon is automatically added to a pkgdown site when a github link is found in DESCRIPTION