### PR TITLE
Convert "layer" argument to "layer_id" in Shiny functions

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -8,19 +8,21 @@
 #' @return A proxy object for the Mapbox GL map.
 #' @export
 mapboxgl_proxy <- function(mapId, session = shiny::getDefaultReactiveDomain()) {
-    if (is.null(session)) {
-        stop("mapboxgl_proxy must be called from within a Shiny session")
-    }
+  if (is.null(session)) {
+    stop("mapboxgl_proxy must be called from within a Shiny session")
+  }
 
-    if (!is.null(session$ns) &&
-        nzchar(session$ns(NULL)) &&
-        substring(mapId, 1, nchar(session$ns(""))) != session$ns("")) {
-        mapId <- session$ns(mapId)
-    }
+  if (
+    !is.null(session$ns) &&
+      nzchar(session$ns(NULL)) &&
+      substring(mapId, 1, nchar(session$ns(""))) != session$ns("")
+  ) {
+    mapId <- session$ns(mapId)
+  }
 
-    proxy <- list(id = mapId, session = session)
-    class(proxy) <- "mapboxgl_proxy"
-    proxy
+  proxy <- list(id = mapId, session = session)
+  class(proxy) <- "mapboxgl_proxy"
+  proxy
 }
 
 #' Create a proxy object for a Maplibre GL map in Shiny
@@ -33,19 +35,21 @@ mapboxgl_proxy <- function(mapId, session = shiny::getDefaultReactiveDomain()) {
 #' @return A proxy object for the Maplibre GL map.
 #' @export
 maplibre_proxy <- function(mapId, session = shiny::getDefaultReactiveDomain()) {
-    if (is.null(session)) {
-        stop("maplibre_proxy must be called from within a Shiny session")
-    }
+  if (is.null(session)) {
+    stop("maplibre_proxy must be called from within a Shiny session")
+  }
 
-    if (!is.null(session$ns) &&
-        nzchar(session$ns(NULL)) &&
-        substring(mapId, 1, nchar(session$ns(""))) != session$ns("")) {
-        mapId <- session$ns(mapId)
-    }
+  if (
+    !is.null(session$ns) &&
+      nzchar(session$ns(NULL)) &&
+      substring(mapId, 1, nchar(session$ns(""))) != session$ns("")
+  ) {
+    mapId <- session$ns(mapId)
+  }
 
-    proxy <- list(id = mapId, session = session)
-    class(proxy) <- "maplibre_proxy"
-    proxy
+  proxy <- list(id = mapId, session = session)
+  class(proxy) <- "maplibre_proxy"
+  proxy
 }
 
 #' Set a filter on a map layer
@@ -59,32 +63,46 @@ maplibre_proxy <- function(mapId, session = shiny::getDefaultReactiveDomain()) {
 #' @return The updated map object.
 #' @export
 set_filter <- function(map, layer_id, filter) {
-    if (any(inherits(map, "mapboxgl_proxy"), inherits(map, "maplibre_proxy"))) {
-        if (inherits(map, "mapboxgl_compare_proxy") || inherits(map, "maplibre_compare_proxy")) {
-            # For compare proxies, use the appropriate message handler
-            proxy_class <- if (inherits(map, "mapboxgl_compare_proxy")) "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
-            map$session$sendCustomMessage(proxy_class, list(
-                id = map$id,
-                message = list(
-                    type = "set_filter", 
-                    layer = layer_id, 
-                    filter = filter,
-                    map = map$map_side  # Add which map to target
-                )
-            ))
-        } else {
-            # For regular proxies, use existing message handler
-            proxy_class <- if (inherits(map, "mapboxgl_proxy")) "mapboxgl-proxy" else "maplibre-proxy"
-            map$session$sendCustomMessage(proxy_class, list(
-                id = map$id,
-                message = list(type = "set_filter", layer = layer_id, filter = filter)
-            ))
-        }
+  if (any(inherits(map, "mapboxgl_proxy"), inherits(map, "maplibre_proxy"))) {
+    if (
+      inherits(map, "mapboxgl_compare_proxy") ||
+        inherits(map, "maplibre_compare_proxy")
+    ) {
+      # For compare proxies, use the appropriate message handler
+      proxy_class <- if (inherits(map, "mapboxgl_compare_proxy"))
+        "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
+      map$session$sendCustomMessage(
+        proxy_class,
+        list(
+          id = map$id,
+          message = list(
+            type = "set_filter",
+            layer = layer_id,
+            filter = filter,
+            map = map$map_side # Add which map to target
+          )
+        )
+      )
     } else {
-        if (is.null(map$x$setFilter)) map$x$setFilter <- list()
-        map$x$setFilter[[length(map$x$setFilter) + 1]] <- list(layer = layer_id, filter = filter)
+      # For regular proxies, use existing message handler
+      proxy_class <- if (inherits(map, "mapboxgl_proxy")) "mapboxgl-proxy" else
+        "maplibre-proxy"
+      map$session$sendCustomMessage(
+        proxy_class,
+        list(
+          id = map$id,
+          message = list(type = "set_filter", layer = layer_id, filter = filter)
+        )
+      )
     }
-    return(map)
+  } else {
+    if (is.null(map$x$setFilter)) map$x$setFilter <- list()
+    map$x$setFilter[[length(map$x$setFilter) + 1]] <- list(
+      layer = layer_id,
+      filter = filter
+    )
+  }
+  return(map)
 }
 
 #' Clear a layer from a map using a proxy
@@ -97,104 +115,166 @@ set_filter <- function(map, layer_id, filter) {
 #' @return The updated proxy object.
 #' @export
 clear_layer <- function(proxy, layer_id) {
-    if (!any(inherits(proxy, "mapboxgl_proxy"), inherits(proxy, "maplibre_proxy"))) {
-        stop("Invalid proxy object")
-    }
+  if (
+    !any(inherits(proxy, "mapboxgl_proxy"), inherits(proxy, "maplibre_proxy"))
+  ) {
+    stop("Invalid proxy object")
+  }
 
-    if (inherits(proxy, "mapboxgl_compare_proxy") || inherits(proxy, "maplibre_compare_proxy")) {
-        # For compare proxies
-        proxy_class <- if (inherits(proxy, "mapboxgl_compare_proxy")) "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
-        message <- list(
-            type = "remove_layer", 
-            layer = layer_id,
-            map = proxy$map_side
-        )
-    } else {
-        # For regular proxies
-        proxy_class <- if (inherits(proxy, "mapboxgl_proxy")) "mapboxgl-proxy" else "maplibre-proxy"
-        message <- list(type = "remove_layer", layer = layer_id)
-    }
-    
-    proxy$session$sendCustomMessage(proxy_class, list(id = proxy$id, message = message))
-    proxy
+  if (
+    inherits(proxy, "mapboxgl_compare_proxy") ||
+      inherits(proxy, "maplibre_compare_proxy")
+  ) {
+    # For compare proxies
+    proxy_class <- if (inherits(proxy, "mapboxgl_compare_proxy"))
+      "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
+    message <- list(
+      type = "remove_layer",
+      layer = layer_id,
+      map = proxy$map_side
+    )
+  } else {
+    # For regular proxies
+    proxy_class <- if (inherits(proxy, "mapboxgl_proxy")) "mapboxgl-proxy" else
+      "maplibre-proxy"
+    message <- list(type = "remove_layer", layer = layer_id)
+  }
+
+  proxy$session$sendCustomMessage(
+    proxy_class,
+    list(id = proxy$id, message = message)
+  )
+  proxy
 }
 
 #' Set a layout property on a map layer
 #'
 #' @param map A map object created by the `mapboxgl` or `maplibre` function, or a proxy object.
-#' @param layer The ID of the layer to update.
+#' @param layer_id The ID of the layer to update.
 #' @param name The name of the layout property to set.
 #' @param value The value to set the property to.
+#' @param ... Additional arguments for compatibility with versions <= v0.2.1.
 #'
 #' @return The updated map object.
 #' @export
-set_layout_property <- function(map, layer, name, value) {
-    if (any(inherits(map, "mapboxgl_proxy"), inherits(map, "maplibre_proxy"))) {
-        if (inherits(map, "mapboxgl_compare_proxy") || inherits(map, "maplibre_compare_proxy")) {
-            # For compare proxies
-            proxy_class <- if (inherits(map, "mapboxgl_compare_proxy")) "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
-            map$session$sendCustomMessage(proxy_class, list(
-                id = map$id,
-                message = list(
-                    type = "set_layout_property", 
-                    layer = layer, 
-                    name = name, 
-                    value = value,
-                    map = map$map_side
-                )
-            ))
-        } else {
-            # For regular proxies
-            proxy_class <- if (inherits(map, "mapboxgl_proxy")) "mapboxgl-proxy" else "maplibre-proxy"
-            map$session$sendCustomMessage(proxy_class, list(
-                id = map$id,
-                message = list(type = "set_layout_property", layer = layer, name = name, value = value)
-            ))
-        }
+set_layout_property <- function(map, layer_id, name, value, ...) {
+  # For compatibility with versions <= v0.2.1
+  if (missingArg(layer_id)) {
+    layer_id <- list(...)$layer
+  }
+
+  if (any(inherits(map, "mapboxgl_proxy"), inherits(map, "maplibre_proxy"))) {
+    if (
+      inherits(map, "mapboxgl_compare_proxy") ||
+        inherits(map, "maplibre_compare_proxy")
+    ) {
+      # For compare proxies
+      proxy_class <- if (inherits(map, "mapboxgl_compare_proxy"))
+        "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
+      map$session$sendCustomMessage(
+        proxy_class,
+        list(
+          id = map$id,
+          message = list(
+            type = "set_layout_property",
+            layer = layer_id,
+            name = name,
+            value = value,
+            map = map$map_side
+          )
+        )
+      )
     } else {
-        if (is.null(map$x$setLayoutProperty)) map$x$setLayoutProperty <- list()
-        map$x$setLayoutProperty[[length(map$x$setLayoutProperty) + 1]] <- list(layer = layer, name = name, value = value)
+      # For regular proxies
+      proxy_class <- if (inherits(map, "mapboxgl_proxy")) "mapboxgl-proxy" else
+        "maplibre-proxy"
+      map$session$sendCustomMessage(
+        proxy_class,
+        list(
+          id = map$id,
+          message = list(
+            type = "set_layout_property",
+            layer = layer_id,
+            name = name,
+            value = value
+          )
+        )
+      )
     }
-    return(map)
+  } else {
+    if (is.null(map$x$setLayoutProperty)) map$x$setLayoutProperty <- list()
+    map$x$setLayoutProperty[[length(map$x$setLayoutProperty) + 1]] <- list(
+      layer = layer_id,
+      name = name,
+      value = value
+    )
+  }
+  return(map)
 }
 
 #' Set a paint property on a map layer
 #'
 #' @param map A map object created by the `mapboxgl` or `maplibre` function, or a proxy object.
-#' @param layer The ID of the layer to update.
+#' @param layer_id The ID of the layer to update.
 #' @param name The name of the paint property to set.
 #' @param value The value to set the property to.
+#' @param ... Additional arguments for compatibility with versions <= v0.2.1.
 #'
 #' @return The updated map object.
 #' @export
-set_paint_property <- function(map, layer, name, value) {
-    if (any(inherits(map, "mapboxgl_proxy"), inherits(map, "maplibre_proxy"))) {
-        if (inherits(map, "mapboxgl_compare_proxy") || inherits(map, "maplibre_compare_proxy")) {
-            # For compare proxies
-            proxy_class <- if (inherits(map, "mapboxgl_compare_proxy")) "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
-            map$session$sendCustomMessage(proxy_class, list(
-                id = map$id,
-                message = list(
-                    type = "set_paint_property", 
-                    layer = layer, 
-                    name = name, 
-                    value = value,
-                    map = map$map_side
-                )
-            ))
-        } else {
-            # For regular proxies
-            proxy_class <- if (inherits(map, "mapboxgl_proxy")) "mapboxgl-proxy" else "maplibre-proxy"
-            map$session$sendCustomMessage(proxy_class, list(
-                id = map$id,
-                message = list(type = "set_paint_property", layer = layer, name = name, value = value)
-            ))
-        }
+set_paint_property <- function(map, layer_id, name, value, ...) {
+  # For compatibility with versions <= v0.2.1
+  if (missingArg(layer_id)) {
+    layer_id <- list(...)$layer
+  }
+
+  if (any(inherits(map, "mapboxgl_proxy"), inherits(map, "maplibre_proxy"))) {
+    if (
+      inherits(map, "mapboxgl_compare_proxy") ||
+        inherits(map, "maplibre_compare_proxy")
+    ) {
+      # For compare proxies
+      proxy_class <- if (inherits(map, "mapboxgl_compare_proxy"))
+        "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
+      map$session$sendCustomMessage(
+        proxy_class,
+        list(
+          id = map$id,
+          message = list(
+            type = "set_paint_property",
+            layer = layer_id,
+            name = name,
+            value = value,
+            map = map$map_side
+          )
+        )
+      )
     } else {
-        if (is.null(map$x$setPaintProperty)) map$x$setPaintProperty <- list()
-        map$x$setPaintProperty[[length(map$x$setPaintProperty) + 1]] <- list(layer = layer, name = name, value = value)
+      # For regular proxies
+      proxy_class <- if (inherits(map, "mapboxgl_proxy")) "mapboxgl-proxy" else
+        "maplibre-proxy"
+      map$session$sendCustomMessage(
+        proxy_class,
+        list(
+          id = map$id,
+          message = list(
+            type = "set_paint_property",
+            layer = layer_id,
+            name = name,
+            value = value
+          )
+        )
+      )
     }
-    return(map)
+  } else {
+    if (is.null(map$x$setPaintProperty)) map$x$setPaintProperty <- list()
+    map$x$setPaintProperty[[length(map$x$setPaintProperty) + 1]] <- list(
+      layer = layer_id,
+      name = name,
+      value = value
+    )
+  }
+  return(map)
 }
 
 #' Clear markers from a map in a Shiny session
@@ -204,26 +284,39 @@ set_paint_property <- function(map, layer, name, value) {
 #' @return The modified map object with the markers cleared.
 #' @export
 clear_markers <- function(map) {
-    if (any(inherits(map, "mapboxgl_proxy"), inherits(map, "maplibre_proxy"))) {
-        if (inherits(map, "mapboxgl_compare_proxy") || inherits(map, "maplibre_compare_proxy")) {
-            # For compare proxies
-            proxy_class <- if (inherits(map, "mapboxgl_compare_proxy")) "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
-            map$session$sendCustomMessage(proxy_class, list(
-                id = map$id, 
-                message = list(
-                    type = "clear_markers",
-                    map = map$map_side
-                )
-            ))
-        } else {
-            # For regular proxies
-            proxy_class <- if (inherits(map, "mapboxgl_proxy")) "mapboxgl-proxy" else "maplibre-proxy"
-            map$session$sendCustomMessage(proxy_class, list(id = map$id, message = list(type = "clear_markers")))
-        }
+  if (any(inherits(map, "mapboxgl_proxy"), inherits(map, "maplibre_proxy"))) {
+    if (
+      inherits(map, "mapboxgl_compare_proxy") ||
+        inherits(map, "maplibre_compare_proxy")
+    ) {
+      # For compare proxies
+      proxy_class <- if (inherits(map, "mapboxgl_compare_proxy"))
+        "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
+      map$session$sendCustomMessage(
+        proxy_class,
+        list(
+          id = map$id,
+          message = list(
+            type = "clear_markers",
+            map = map$map_side
+          )
+        )
+      )
     } else {
-        stop("clear_markers() can only be used with mapboxgl_proxy(), maplibre_proxy(), mapboxgl_compare_proxy(), or maplibre_compare_proxy()")
+      # For regular proxies
+      proxy_class <- if (inherits(map, "mapboxgl_proxy")) "mapboxgl-proxy" else
+        "maplibre-proxy"
+      map$session$sendCustomMessage(
+        proxy_class,
+        list(id = map$id, message = list(type = "clear_markers"))
+      )
     }
-    return(map)
+  } else {
+    stop(
+      "clear_markers() can only be used with mapboxgl_proxy(), maplibre_proxy(), mapboxgl_compare_proxy(), or maplibre_compare_proxy()"
+    )
+  }
+  return(map)
 }
 
 #' Update the style of a map
@@ -252,37 +345,50 @@ clear_markers <- function(map) {
 #' })
 #' }
 set_style <- function(map, style, config = NULL, diff = TRUE) {
-    if (any(inherits(map, "mapboxgl_proxy"), inherits(map, "maplibre_proxy"))) {
-        if (inherits(map, "mapboxgl_compare_proxy") || inherits(map, "maplibre_compare_proxy")) {
-            # For compare proxies
-            proxy_class <- if (inherits(map, "mapboxgl_compare_proxy")) "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
-            map$session$sendCustomMessage(proxy_class, list(
-                id = map$id,
-                message = list(
-                    type = "set_style",
-                    style = style,
-                    config = config,
-                    diff = diff,
-                    map = map$map_side
-                )
-            ))
-        } else {
-            # For regular proxies
-            proxy_class <- if (inherits(map, "mapboxgl_proxy")) "mapboxgl-proxy" else "maplibre-proxy"
-            map$session$sendCustomMessage(proxy_class, list(
-                id = map$id,
-                message = list(
-                    type = "set_style",
-                    style = style,
-                    config = config,
-                    diff = diff
-                )
-            ))
-        }
+  if (any(inherits(map, "mapboxgl_proxy"), inherits(map, "maplibre_proxy"))) {
+    if (
+      inherits(map, "mapboxgl_compare_proxy") ||
+        inherits(map, "maplibre_compare_proxy")
+    ) {
+      # For compare proxies
+      proxy_class <- if (inherits(map, "mapboxgl_compare_proxy"))
+        "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
+      map$session$sendCustomMessage(
+        proxy_class,
+        list(
+          id = map$id,
+          message = list(
+            type = "set_style",
+            style = style,
+            config = config,
+            diff = diff,
+            map = map$map_side
+          )
+        )
+      )
     } else {
-        stop("set_style can only be used with mapboxgl_proxy, maplibre_proxy, mapboxgl_compare_proxy, or maplibre_compare_proxy.")
+      # For regular proxies
+      proxy_class <- if (inherits(map, "mapboxgl_proxy")) "mapboxgl-proxy" else
+        "maplibre-proxy"
+      map$session$sendCustomMessage(
+        proxy_class,
+        list(
+          id = map$id,
+          message = list(
+            type = "set_style",
+            style = style,
+            config = config,
+            diff = diff
+          )
+        )
+      )
     }
-    return(map)
+  } else {
+    stop(
+      "set_style can only be used with mapboxgl_proxy, maplibre_proxy, mapboxgl_compare_proxy, or maplibre_compare_proxy."
+    )
+  }
+  return(map)
 }
 
 #' Move a layer to a different z-position
@@ -296,65 +402,98 @@ set_style <- function(map, style, config = NULL, diff = TRUE) {
 #' @return The updated proxy object.
 #' @export
 move_layer <- function(proxy, layer_id, before_id = NULL) {
-    if (!any(inherits(proxy, "mapboxgl_proxy"), inherits(proxy, "maplibre_proxy"))) {
-        stop("Invalid proxy object")
-    }
+  if (
+    !any(inherits(proxy, "mapboxgl_proxy"), inherits(proxy, "maplibre_proxy"))
+  ) {
+    stop("Invalid proxy object")
+  }
 
-    if (inherits(proxy, "mapboxgl_compare_proxy") || inherits(proxy, "maplibre_compare_proxy")) {
-        # For compare proxies
-        proxy_class <- if (inherits(proxy, "mapboxgl_compare_proxy")) "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
-        message <- list(
-            type = "move_layer",
-            layer = layer_id,
-            before = before_id,
-            map = proxy$map_side
-        )
-    } else {
-        # For regular proxies
-        proxy_class <- if (inherits(proxy, "mapboxgl_proxy")) "mapboxgl-proxy" else "maplibre-proxy"
-        message <- list(
-            type = "move_layer",
-            layer = layer_id,
-            before = before_id
-        )
-    }
+  if (
+    inherits(proxy, "mapboxgl_compare_proxy") ||
+      inherits(proxy, "maplibre_compare_proxy")
+  ) {
+    # For compare proxies
+    proxy_class <- if (inherits(proxy, "mapboxgl_compare_proxy"))
+      "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
+    message <- list(
+      type = "move_layer",
+      layer = layer_id,
+      before = before_id,
+      map = proxy$map_side
+    )
+  } else {
+    # For regular proxies
+    proxy_class <- if (inherits(proxy, "mapboxgl_proxy")) "mapboxgl-proxy" else
+      "maplibre-proxy"
+    message <- list(
+      type = "move_layer",
+      layer = layer_id,
+      before = before_id
+    )
+  }
 
-    proxy$session$sendCustomMessage(proxy_class, list(id = proxy$id, message = message))
-    proxy
+  proxy$session$sendCustomMessage(
+    proxy_class,
+    list(id = proxy$id, message = message)
+  )
+  proxy
 }
 
 #' Set tooltip on a map layer
 #'
 #' @param map A map object created by the `mapboxgl` or `maplibre` function, or a proxy object.
-#' @param layer The ID of the layer to update.
+#' @param layer_id The ID of the layer to update.
 #' @param tooltip  The name of the tooltip to set.
+#' @param ... Additional arguments for compatibility with versions <= v0.2.1.
 #'
 #' @return The updated map object.
 #' @export
-set_tooltip  <- function(map, layer, tooltip) {
+set_tooltip <- function(map, layer_id, tooltip, ...) {
+  # For compatibility with versions <= v0.2.1
+  if (missingArg(layer_id)) {
+    layer_id <- list(...)$layer
+  }
+
   if (any(inherits(map, "mapboxgl_proxy"), inherits(map, "maplibre_proxy"))) {
-    if (inherits(map, "mapboxgl_compare_proxy") || inherits(map, "maplibre_compare_proxy")) {
+    if (
+      inherits(map, "mapboxgl_compare_proxy") ||
+        inherits(map, "maplibre_compare_proxy")
+    ) {
       # For compare proxies
-      proxy_class <- if (inherits(map, "mapboxgl_compare_proxy")) "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
-      map$session$sendCustomMessage(proxy_class, list(
-        id = map$id,
-        message = list(
-          type = "set_tooltip", 
-          layer = layer, 
-          tooltip = tooltip,
-          map = map$map_side
+      proxy_class <- if (inherits(map, "mapboxgl_compare_proxy"))
+        "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
+      map$session$sendCustomMessage(
+        proxy_class,
+        list(
+          id = map$id,
+          message = list(
+            type = "set_tooltip",
+            layer = layer_id,
+            tooltip = tooltip,
+            map = map$map_side
+          )
         )
-      ))
+      )
     } else {
       # For regular proxies
-      proxy_class <- if (inherits(map, "mapboxgl_proxy")) "mapboxgl-proxy" else "maplibre-proxy"
-      map$session$sendCustomMessage(proxy_class, list(
-        id = map$id,
-        message = list(type = "set_tooltip", layer = layer, tooltip = tooltip)
-      ))
+      proxy_class <- if (inherits(map, "mapboxgl_proxy")) "mapboxgl-proxy" else
+        "maplibre-proxy"
+      map$session$sendCustomMessage(
+        proxy_class,
+        list(
+          id = map$id,
+          message = list(
+            type = "set_tooltip",
+            layer = layer_id,
+            tooltip = tooltip
+          )
+        )
+      )
     }
   } else {
-    stop("set_tooltip can only be used with mapboxgl_proxy, maplibre_proxy, mapboxgl_compare_proxy, or maplibre_compare_proxy.")
+    stop(
+      "set_tooltip can only be used with mapboxgl_proxy, maplibre_proxy, mapboxgl_compare_proxy, or maplibre_compare_proxy."
+    )
   }
   return(map)
 }
@@ -362,40 +501,63 @@ set_tooltip  <- function(map, layer, tooltip) {
 #' Set source of a map layer
 #'
 #' @param map A map object created by the `mapboxgl` or `maplibre` function, or a proxy object.
-#' @param layer The ID of the layer to update.
+#' @param layer_id The ID of the layer to update.
 #' @param source An sf object (which will be converted to a GeoJSON source).
+#' @param ... Additional arguments for compatibility with versions <= v0.2.1.
 #'
 #' @return The updated map object.
 #' @export
-set_source  <- function(map, layer, source) {
+set_source <- function(map, layer_id, source, ...) {
+  # For compatibility with versions <= v0.2.1
+  if (missingArg(layer_id)) {
+    layer_id <- list(...)$layer
+  }
+
   if (any(inherits(map, "mapboxgl_proxy"), inherits(map, "maplibre_proxy"))) {
     # Convert sf objects to GeoJSON source
     if (inherits(source, "sf")) {
       source <- geojsonsf::sf_geojson(sf::st_transform(source, crs = 4326))
     }
 
-    if (inherits(map, "mapboxgl_compare_proxy") || inherits(map, "maplibre_compare_proxy")) {
+    if (
+      inherits(map, "mapboxgl_compare_proxy") ||
+        inherits(map, "maplibre_compare_proxy")
+    ) {
       # For compare proxies
-      proxy_class <- if (inherits(map, "mapboxgl_compare_proxy")) "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
-      map$session$sendCustomMessage(proxy_class, list(
-        id = map$id,
-        message = list(
-          type = "set_source", 
-          layer = layer, 
-          source = source,
-          map = map$map_side
+      proxy_class <- if (inherits(map, "mapboxgl_compare_proxy"))
+        "mapboxgl-compare-proxy" else "maplibre-compare-proxy"
+      map$session$sendCustomMessage(
+        proxy_class,
+        list(
+          id = map$id,
+          message = list(
+            type = "set_source",
+            layer = layer_id,
+            source = source,
+            map = map$map_side
+          )
         )
-      ))
+      )
     } else {
       # For regular proxies
-      proxy_class <- if (inherits(map, "mapboxgl_proxy")) "mapboxgl-proxy" else "maplibre-proxy"
-      map$session$sendCustomMessage(proxy_class, list(
-        id = map$id,
-        message = list(type = "set_source", layer = layer, source = source)
-      ))
+      proxy_class <- if (inherits(map, "mapboxgl_proxy")) "mapboxgl-proxy" else
+        "maplibre-proxy"
+      map$session$sendCustomMessage(
+        proxy_class,
+        list(
+          id = map$id,
+          message = list(
+            type = "set_source",
+            layer = layer_id,
+            source = source
+          )
+        )
+      )
     }
   } else {
-    stop("set_source can only be used with mapboxgl_proxy, maplibre_proxy, mapboxgl_compare_proxy, or maplibre_compare_proxy.")
+    stop(
+      "set_source can only be used with mapboxgl_proxy, maplibre_proxy, mapboxgl_compare_proxy, or maplibre_compare_proxy."
+    )
   }
   return(map)
 }

--- a/man/set_layout_property.Rd
+++ b/man/set_layout_property.Rd
@@ -4,16 +4,18 @@
 \alias{set_layout_property}
 \title{Set a layout property on a map layer}
 \usage{
-set_layout_property(map, layer, name, value)
+set_layout_property(map, layer_id, name, value, ...)
 }
 \arguments{
 \item{map}{A map object created by the \code{mapboxgl} or \code{maplibre} function, or a proxy object.}
 
-\item{layer}{The ID of the layer to update.}
+\item{layer_id}{The ID of the layer to update.}
 
 \item{name}{The name of the layout property to set.}
 
 \item{value}{The value to set the property to.}
+
+\item{...}{Additional arguments for compatibility with versions <= v0.2.1.}
 }
 \value{
 The updated map object.

--- a/man/set_paint_property.Rd
+++ b/man/set_paint_property.Rd
@@ -4,16 +4,18 @@
 \alias{set_paint_property}
 \title{Set a paint property on a map layer}
 \usage{
-set_paint_property(map, layer, name, value)
+set_paint_property(map, layer_id, name, value, ...)
 }
 \arguments{
 \item{map}{A map object created by the \code{mapboxgl} or \code{maplibre} function, or a proxy object.}
 
-\item{layer}{The ID of the layer to update.}
+\item{layer_id}{The ID of the layer to update.}
 
 \item{name}{The name of the paint property to set.}
 
 \item{value}{The value to set the property to.}
+
+\item{...}{Additional arguments for compatibility with versions <= v0.2.1.}
 }
 \value{
 The updated map object.

--- a/man/set_source.Rd
+++ b/man/set_source.Rd
@@ -4,14 +4,16 @@
 \alias{set_source}
 \title{Set source of a map layer}
 \usage{
-set_source(map, layer, source)
+set_source(map, layer_id, source, ...)
 }
 \arguments{
 \item{map}{A map object created by the \code{mapboxgl} or \code{maplibre} function, or a proxy object.}
 
-\item{layer}{The ID of the layer to update.}
+\item{layer_id}{The ID of the layer to update.}
 
 \item{source}{An sf object (which will be converted to a GeoJSON source).}
+
+\item{...}{Additional arguments for compatibility with versions <= v0.2.1.}
 }
 \value{
 The updated map object.

--- a/man/set_tooltip.Rd
+++ b/man/set_tooltip.Rd
@@ -4,14 +4,16 @@
 \alias{set_tooltip}
 \title{Set tooltip on a map layer}
 \usage{
-set_tooltip(map, layer, tooltip)
+set_tooltip(map, layer_id, tooltip, ...)
 }
 \arguments{
 \item{map}{A map object created by the \code{mapboxgl} or \code{maplibre} function, or a proxy object.}
 
-\item{layer}{The ID of the layer to update.}
+\item{layer_id}{The ID of the layer to update.}
 
 \item{tooltip}{The name of the tooltip to set.}
+
+\item{...}{Additional arguments for compatibility with versions <= v0.2.1.}
 }
 \value{
 The updated map object.


### PR DESCRIPTION
Response to #86.

There are a bunch of misc. [Air](https://www.tidyverse.org/blog/2025/02/air/) formatting changes in there (sorry!), so here are the pertinent changes for your review:

- Convert `layer` argument to `layer_id` and add dots (incl. to roxygen comments)
  - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L160
  - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L225
  - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L451
  - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L510
- If `layer_id` is missing, check for `layer` argument in dots. For compatibility with code written in previous versions where the argument was explicitly used.
  - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L162
  - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L227
  - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L453
  - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L512
 - Change misc. `layer = layer` to `layer = layer_id`
   - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L180
   - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L197
   - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L207
   - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L227
   - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L262
   - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L272
   - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L471
   - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L487
   - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L535
   - https://github.com/mhpob/mapgl/blob/e96a53166d86dc916e4b22d8547b7e27f8ecf238/R/shiny.R#L551