### PR TITLE
trim map ID for indexing session$input in get_drawn_features

### DIFF
--- a/R/controls.R
+++ b/R/controls.R
@@ -108,7 +108,7 @@ add_navigation_control <- function(map,
             } else {
                 "maplibre-proxy"
             }
-            
+
             map$session$sendCustomMessage(proxy_class, list(
                 id = map$id,
                 message = list(
@@ -328,7 +328,7 @@ add_scale_control <- function(map,
             map$session$sendCustomMessage(proxy_class, list(
                 id = map$id,
                 message = list(
-                    type = "add_scale_control", 
+                    type = "add_scale_control",
                     options = scale_control,
                     map = map$map_side
                 )
@@ -536,13 +536,15 @@ get_drawn_features <- function(map) {
         ))
     }
 
+    # Trim any module namespacing off to index the session proxy inputs
+    map_drawn_id <- sub(pattern = session$ns(""), replacement = "", x = paste0(map_id, "_drawn_features"))
     # Wait for response
     features_json <- NULL
     wait_time <- 0
     while (is.null(features_json) &&
         wait_time < 3) {
         # Wait up to 3 seconds
-        features_json <- session$input[[paste0(map_id, "_drawn_features")]]
+        features_json <- session$input[[map_drawn_id]]
         Sys.sleep(0.1)
         wait_time <- wait_time + 0.1
     }
@@ -601,7 +603,7 @@ add_geocoder_control <- function(map,
             map$session$sendCustomMessage(proxy_class, list(
                 id = map$id,
                 message = list(
-                    type = "add_geocoder_control", 
+                    type = "add_geocoder_control",
                     options = geocoder_options,
                     map = map$map_side
                 )
@@ -669,7 +671,7 @@ add_reset_control <- function(map,
             map$session$sendCustomMessage(proxy_class, list(
                 id = map$id,
                 message = list(
-                    type = "add_reset_control", 
+                    type = "add_reset_control",
                     options = reset_control,
                     map = map$map_side
                 )
@@ -756,7 +758,7 @@ add_geolocate_control <- function(map,
             map$session$sendCustomMessage(proxy_class, list(
                 id = map$id,
                 message = list(
-                    type = "add_geolocate_control", 
+                    type = "add_geolocate_control",
                     options = geolocate_control,
                     map = map$map_side
                 )


### PR DESCRIPTION
This is to address a bug in the `get_drawn_features` function that prevents use with shiny modules (#82). This fix trims any module prefix so that the map input ID matches the module `session$input`. 

## Use in a module

```r
 # In a Shiny application
  library(shiny)
  library(mapgl)

  map_UI <- function(id) {
    ns <- NS(id)
    tagList(
      mapboxglOutput(ns("map")),
      actionButton(ns("get_features"), "Get Drawn Features"),
      verbatimTextOutput(ns("feature_output"))
    )
  }

  map_SERVER <- function(id, api) {
    moduleServer(id, function(input, output, session) {
      output$map <- renderMapboxgl({
        mapboxgl(
          style = mapbox_style("streets"),
          center = c(-74.50, 40),
          zoom = 9
        ) |>
          add_draw_control()
      })

      observeEvent(input$get_features, {
        proxy <- mapboxgl_proxy("map")
        drawn_features <- get_drawn_features(proxy)
        output$feature_output <- renderPrint({
          print(drawn_features)
        })
      })
    })
  }

  ui <- fluidPage(
    map_UI("map")
  )

  server <- function(input, output, session) {
    map_SERVER("map")
  }

  shinyApp(ui, server)
``` 

## Use with no module

```r
library(shiny)
library(mapgl)

ui <- fluidPage(
    mapboxglOutput("map"),
    actionButton("get_features", "Get Drawn Features"),
    verbatimTextOutput("feature_output")
)

server <- function(input, output, session) {
    output$map <- renderMapboxgl({
        mapboxgl(
            style = mapbox_style("streets"),
            center = c(-74.50, 40),
            zoom = 9
        ) |>
            add_draw_control()
    })

    observeEvent(input$get_features, {
        drawn_features <- get_drawn_features(mapboxgl_proxy("map"))
        output$feature_output <- renderPrint({
            print(drawn_features)
        })
    })
}

shinyApp(ui, server)
```