### PR TITLE
add `promoteId` argument to `add_vector_source()` for enabling hover effects with 3rd party vector tiles

### DIFF
--- a/R/sources.R
+++ b/R/sources.R
@@ -61,15 +61,26 @@ add_source <- function(map, id, data, ...) {
 #' @param map A map object created by the `mapboxgl` or `maplibre` function.
 #' @param id A unique ID for the source.
 #' @param url A URL pointing to the vector tile source.
+#' @param promoteId An optional property name to use as the feature ID. This is required for hover effects on vector tiles.
+#' @param ... Additional arguments to be passed to the JavaScript addSource method.
 #'
 #' @return The modified map object with the new source added.
 #' @export
-add_vector_source <- function(map, id, url) {
+add_vector_source <- function(map, id, url, promoteId = NULL, ...) {
     source <- list(
         id = id,
         type = "vector",
         url = url
     )
+
+    if (!is.null(promoteId)) {
+        source$promoteId <- promoteId
+    }
+
+    # Add any additional arguments
+    extra_args <- list(...)
+    source <- c(source, extra_args)
+
 
     if (inherits(map, "mapboxgl_proxy") || inherits(map, "maplibre_proxy")) {
         if (inherits(map, "mapboxgl_compare_proxy") || inherits(map, "maplibre_compare_proxy")) {

--- a/inst/htmlwidgets/mapboxgl.js
+++ b/inst/htmlwidgets/mapboxgl.js
@@ -361,10 +361,21 @@ HTMLWidgets.widget({
                     if (x.sources) {
                         x.sources.forEach(function (source) {
                             if (source.type === "vector") {
-                                map.addSource(source.id, {
+                                const sourceOptions = {
                                     type: "vector",
                                     url: source.url,
-                                });
+                                };
+                                // Add promoteId if provided
+                                if (source.promoteId) {
+                                    sourceOptions.promoteId = source.promoteId;
+                                }
+                                // Add any other additional options
+                                for (const [key, value] of Object.entries(source)) {
+                                    if (!["id", "type", "url"].includes(key)) {
+                                        sourceOptions[key] = value;
+                                    }
+                                }
+                                map.addSource(source.id, sourceOptions);
                             } else if (source.type === "geojson") {
                                 const geojsonData = source.data;
                                 const sourceOptions = {

--- a/inst/htmlwidgets/maplibregl.js
+++ b/inst/htmlwidgets/maplibregl.js
@@ -362,10 +362,21 @@ HTMLWidgets.widget({
                     if (x.sources) {
                         x.sources.forEach(function (source) {
                             if (source.type === "vector") {
-                                map.addSource(source.id, {
+                                const sourceOptions = {
                                     type: "vector",
                                     url: source.url,
-                                });
+                                };
+                                // Add promoteId if provided
+                                if (source.promoteId) {
+                                    sourceOptions.promoteId = source.promoteId;
+                                }
+                                // Add any other additional options
+                                for (const [key, value] of Object.entries(source)) {
+                                    if (!["id", "type", "url"].includes(key)) {
+                                        sourceOptions[key] = value;
+                                    }
+                                }
+                                map.addSource(source.id, sourceOptions);
                             } else if (source.type === "geojson") {
                                 const geojsonData = source.data;
                                 const sourceOptions = {

--- a/man/add_vector_source.Rd
+++ b/man/add_vector_source.Rd
@@ -4,7 +4,7 @@
 \alias{add_vector_source}
 \title{Add a vector tile source to a Mapbox GL or Maplibre GL map}
 \usage{
-add_vector_source(map, id, url)
+add_vector_source(map, id, url, promoteId = NULL, ...)
 }
 \arguments{
 \item{map}{A map object created by the \code{mapboxgl} or \code{maplibre} function.}
@@ -12,6 +12,10 @@ add_vector_source(map, id, url)
 \item{id}{A unique ID for the source.}
 
 \item{url}{A URL pointing to the vector tile source.}
+
+\item{promoteId}{An optional property name to use as the feature ID. This is required for hover effects on vector tiles.}
+
+\item{...}{Additional arguments to be passed to the JavaScript addSource method.}
 }
 \value{
 The modified map object with the new source added.


### PR DESCRIPTION
Thank you @walkerke for a fantastic R package! It is filling the void of interactively mapping dense spatial data using easy R and Shiny.

I was having an issue with hover effects not working when using 3rd party vector tiles, ie my own vector tiles served via [pg_tileserv](https://github.com/CrunchyData/pg_tileserv); not `mapbox:`. The `hover_options` would not work at all to highlight the hovered feature like your example using native `mapbox:` layers:

- [Dynamic web maps with Mapbox Tiling Service and mapgl • mapboxapi](https://walker-data.com/mapboxapi/articles/dynamic-maps.html#styling-vector-tiles-with-mapbox-gl-js-and-mapgl)
  ![image](https://github.com/user-attachments/assets/b3326e9d-70e6-4ac2-9853-62be4a7b8ddf)

In the Chrome browser's Javascript console running a Shiny app with `mapboxgl()`, I would see the following error (although the rest of the layer displayed fine; and `maplibre()` would show no JS errors):

  ```
  Error: The feature id parameter must be provided.
      at Eo.setFeatureState (style.ts:2923:38)
      at Map.setFeatureState (map.ts:3978:20)
      at Map.<anonymous> (mapboxgl.js:604:49)
      at Map.s (map.ts:1652:30)
      at Map.fire (evented.ts:152:26)
      at va.mousemove (map_event.ts:129:19)
      at tl.handleEvent (handler_manager.ts:358:51)
  ```

Based on mapbox and mapLibre documentation, I tried adding `generateId = T` (which is actually only for GeoJSON) and `promoteId = "id"` (where my integer coumn "id" uniquely identifies each feature) to the `add_vector_source()` call by modifying the function, but needed to modify the underlying Javascript too (with some help from [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview)). Hopefully you can run this example and see it now works:

```r
mapboxgl(
  style      = mapbox_style("dark"),
  projection = "globe",
  zoom       = 8.71,
  center     = c(-81.2, 28.6) ) |>
  add_vector_source(
    id         = "vect_src",
    url        = 'https://api.marinesensitivity.org/tilejson?table=oceanmetrics.ds_indicators',
    promoteId  = "id" ) |>
  add_fill_layer(
    id            = "vect_ply",
    source        = "vect_src",
    source_layer  = "oceanmetrics.ds_indicators",
    tooltip       = "al_er_su_wr",
    fill_color    = interpolate(
      column = "al_er_su_wr",
      values = seq(0, 1.0, length.out = 11),
      stops  = rev(RColorBrewer::brewer.pal(11, "Spectral")) ),
    fill_opacity  = 0.7,
    hover_options = list(
      fill_color   = "cyan",
      fill_opacity = 1 ) )
```

![Screenshot 2025-06-06 at 4 43 30 PM](https://github.com/user-attachments/assets/d72c5b98-6dad-44b7-be8e-351374444763)
