### PR TITLE
Custom labels & layer groups in the layers control

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mapgl
 Title: Interactive Maps with 'Mapbox GL JS' and 'MapLibre GL JS'
-Version: 0.4.0
-Date: 2025-08-18
+Version: 0.4.0.9000
+Date: 2025-09-14
 Authors@R:
     person(given = "Kyle", family = "Walker", email = "kyle@walker-data.com", role = c("aut", "cre"))
 Description: Provides an interface to the 'Mapbox GL JS' (<https://docs.mapbox.com/mapbox-gl-js/guides>)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mapgl
 Title: Interactive Maps with 'Mapbox GL JS' and 'MapLibre GL JS'
 Version: 0.4.0
-Date: 2025-08-07
+Date: 2025-08-18
 Authors@R:
     person(given = "Kyle", family = "Walker", email = "kyle@walker-data.com", role = c("aut", "cre"))
 Description: Provides an interface to the 'Mapbox GL JS' (<https://docs.mapbox.com/mapbox-gl-js/guides>)

--- a/R/controls.R
+++ b/R/controls.R
@@ -184,6 +184,7 @@ add_navigation_control <- function(
 #'
 #' rds <- roads("TX", "Tarrant")
 #' tr <- tracts("TX", "Tarrant", cb = TRUE)
+#' cty <- counties("TX", cb = TRUE)
 #'
 #' maplibre() |>
 #'     fit_bounds(rds) |>
@@ -216,9 +217,19 @@ add_navigation_control <- function(
 #'     )
 #'
 #' # Group multiple layers together
-#' maplibre() |>
-#'     add_fill_layer(id = "county-fill", source = counties) |>
-#'     add_line_layer(id = "county-outline", source = counties) |>
+#' maplibre(bounds = cty) |>
+#'     add_fill_layer(id = "county-fill", source = cty, fill_opacity = 0.3) |>
+#'     add_line_layer(
+#'         id = "county-outline",
+#'         source = cty,
+#'         line_color = "yellow",
+#'         line_width = 3
+#'     ) |>
+#'     add_line_layer(
+#'         id = "roads-layer",
+#'         source = rds,
+#'         line_color = "blue"
+#'     ) |>
 #'     add_layers_control(
 #'         layers = list(
 #'             "Counties" = c("county-fill", "county-outline"),
@@ -1057,20 +1068,23 @@ add_geocoder_control <- function(
   ...
 ) {
   # Set default provider for MapLibre if NULL
-  if (is.null(provider) && 
-      (inherits(map, "maplibre") || 
-       inherits(map, "maplibre_proxy") || 
-       inherits(map, "maplibre_compare_proxy"))) {
+  if (
+    is.null(provider) &&
+      (inherits(map, "maplibre") ||
+        inherits(map, "maplibre_proxy") ||
+        inherits(map, "maplibre_compare_proxy"))
+  ) {
     provider <- "osm"
   }
-  
+
   # Validate provider parameter for MapLibre
   if (!is.null(provider) && !provider %in% c("osm", "maptiler")) {
     rlang::abort("Provider must be either 'osm' or 'maptiler'")
   }
-  
+
   # Check that provider parameter is only used with MapLibre
-  if (!is.null(provider) &&
+  if (
+    !is.null(provider) &&
       (inherits(map, "mapboxgl") ||
         inherits(map, "mapboxgl_proxy") ||
         inherits(map, "mapboxgl_compare_proxy"))

--- a/inst/htmlwidgets/mapboxgl.js
+++ b/inst/htmlwidgets/mapboxgl.js
@@ -1331,74 +1331,152 @@ HTMLWidgets.widget({
             let layers =
               x.layers_control.layers ||
               map.getStyle().layers.map((layer) => layer.id);
+            let layersConfig = x.layers_control.layers_config;
 
-            // Ensure layers is always an array
-            if (!Array.isArray(layers)) {
-              layers = [layers];
-            }
+            // If we have a layers_config, use that; otherwise fall back to original behavior
+            if (layersConfig && Array.isArray(layersConfig)) {
+              layersConfig.forEach((config, index) => {
+                const link = document.createElement("a");
+                // Ensure config.ids is always an array
+                const layerIds = Array.isArray(config.ids) ? config.ids : [config.ids];
+                link.id = layerIds.join("-");
+                link.href = "#";
+                link.textContent = config.label;
+                link.setAttribute("data-layer-ids", JSON.stringify(layerIds));
+                link.setAttribute("data-layer-type", config.type);
 
-            layers.forEach((layerId, index) => {
-              const link = document.createElement("a");
-              link.id = layerId;
-              link.href = "#";
-              link.textContent = layerId;
-
-              // Check if the layer visibility is set to "none" initially
-              const initialVisibility = map.getLayoutProperty(
-                layerId,
-                "visibility",
-              );
-              link.className = initialVisibility === "none" ? "" : "active";
-
-              // Also hide any associated legends if the layer is initially hidden
-              if (initialVisibility === "none") {
-                const associatedLegends = document.querySelectorAll(
-                  `.mapboxgl-legend[data-layer-id="${layerId}"]`,
-                );
-                associatedLegends.forEach((legend) => {
-                  legend.style.display = "none";
-                });
-              }
-
-              // Show or hide layer when the toggle is clicked
-              link.onclick = function (e) {
-                const clickedLayer = this.textContent;
-                e.preventDefault();
-                e.stopPropagation();
-
-                const visibility = map.getLayoutProperty(
-                  clickedLayer,
+                // Check if the first layer's visibility is set to "none" initially
+                const firstLayerId = layerIds[0];
+                const initialVisibility = map.getLayoutProperty(
+                  firstLayerId,
                   "visibility",
                 );
+                link.className = initialVisibility === "none" ? "" : "active";
 
-                // Toggle layer visibility by changing the layout object's visibility property
-                if (visibility === "visible") {
-                  map.setLayoutProperty(clickedLayer, "visibility", "none");
-                  this.className = "";
+                // Also hide any associated legends if the layer is initially hidden
+                if (initialVisibility === "none") {
+                  layerIds.forEach(layerId => {
+                    const associatedLegends = document.querySelectorAll(
+                      `.mapboxgl-legend[data-layer-id="${layerId}"]`,
+                    );
+                    associatedLegends.forEach((legend) => {
+                      legend.style.display = "none";
+                    });
+                  });
+                }
 
-                  // Hide associated legends
+                // Show or hide layer(s) when the toggle is clicked
+                link.onclick = function (e) {
+                  e.preventDefault();
+                  e.stopPropagation();
+
+                  const layerIds = JSON.parse(this.getAttribute("data-layer-ids"));
+                  const firstLayerId = layerIds[0];
+                  const visibility = map.getLayoutProperty(
+                    firstLayerId,
+                    "visibility",
+                  );
+
+                  // Toggle visibility for all layer IDs in the group
+                  if (visibility === "visible") {
+                    layerIds.forEach(layerId => {
+                      map.setLayoutProperty(layerId, "visibility", "none");
+                      // Hide associated legends
+                      const associatedLegends = document.querySelectorAll(
+                        `.mapboxgl-legend[data-layer-id="${layerId}"]`,
+                      );
+                      associatedLegends.forEach((legend) => {
+                        legend.style.display = "none";
+                      });
+                    });
+                    this.className = "";
+                  } else {
+                    layerIds.forEach(layerId => {
+                      map.setLayoutProperty(layerId, "visibility", "visible");
+                      // Show associated legends
+                      const associatedLegends = document.querySelectorAll(
+                        `.mapboxgl-legend[data-layer-id="${layerId}"]`,
+                      );
+                      associatedLegends.forEach((legend) => {
+                        legend.style.display = "";
+                      });
+                    });
+                    this.className = "active";
+                  }
+                };
+
+                layersList.appendChild(link);
+              });
+            } else {
+              // Fallback to original behavior for simple layer arrays
+              // Ensure layers is always an array
+              if (!Array.isArray(layers)) {
+                layers = [layers];
+              }
+
+              layers.forEach((layerId, index) => {
+                const link = document.createElement("a");
+                link.id = layerId;
+                link.href = "#";
+                link.textContent = layerId;
+
+                // Check if the layer visibility is set to "none" initially
+                const initialVisibility = map.getLayoutProperty(
+                  layerId,
+                  "visibility",
+                );
+                link.className = initialVisibility === "none" ? "" : "active";
+
+                // Also hide any associated legends if the layer is initially hidden
+                if (initialVisibility === "none") {
                   const associatedLegends = document.querySelectorAll(
-                    `.mapboxgl-legend[data-layer-id="${clickedLayer}"]`,
+                    `.mapboxgl-legend[data-layer-id="${layerId}"]`,
                   );
                   associatedLegends.forEach((legend) => {
                     legend.style.display = "none";
                   });
-                } else {
-                  this.className = "active";
-                  map.setLayoutProperty(clickedLayer, "visibility", "visible");
-
-                  // Show associated legends
-                  const associatedLegends = document.querySelectorAll(
-                    `.mapboxgl-legend[data-layer-id="${clickedLayer}"]`,
-                  );
-                  associatedLegends.forEach((legend) => {
-                    legend.style.display = "";
-                  });
                 }
-              };
 
-              layersList.appendChild(link);
-            });
+                // Show or hide layer when the toggle is clicked
+                link.onclick = function (e) {
+                  const clickedLayer = this.textContent;
+                  e.preventDefault();
+                  e.stopPropagation();
+
+                  const visibility = map.getLayoutProperty(
+                    clickedLayer,
+                    "visibility",
+                  );
+
+                  // Toggle layer visibility by changing the layout object's visibility property
+                  if (visibility === "visible") {
+                    map.setLayoutProperty(clickedLayer, "visibility", "none");
+                    this.className = "";
+
+                    // Hide associated legends
+                    const associatedLegends = document.querySelectorAll(
+                      `.mapboxgl-legend[data-layer-id="${clickedLayer}"]`,
+                    );
+                    associatedLegends.forEach((legend) => {
+                      legend.style.display = "none";
+                    });
+                  } else {
+                    this.className = "active";
+                    map.setLayoutProperty(clickedLayer, "visibility", "visible");
+
+                    // Show associated legends
+                    const associatedLegends = document.querySelectorAll(
+                      `.mapboxgl-legend[data-layer-id="${clickedLayer}"]`,
+                    );
+                    associatedLegends.forEach((legend) => {
+                      legend.style.display = "";
+                    });
+                  }
+                };
+
+                layersList.appendChild(link);
+              });
+            }
 
             // Handle collapsible behavior
             if (x.layers_control.collapsible) {
@@ -2871,72 +2949,150 @@ if (HTMLWidgets.shinyMode) {
         layersControl.appendChild(layersList);
 
         let layers = message.layers || [];
+        let layersConfig = message.layers_config;
 
-        // Ensure layers is always an array
-        if (!Array.isArray(layers)) {
-          layers = [layers];
-        }
+        // If we have a layers_config, use that; otherwise fall back to original behavior
+        if (layersConfig && Array.isArray(layersConfig)) {
+          layersConfig.forEach((config, index) => {
+            const link = document.createElement("a");
+            // Ensure config.ids is always an array
+            const layerIds = Array.isArray(config.ids) ? config.ids : [config.ids];
+            link.id = layerIds.join("-");
+            link.href = "#";
+            link.textContent = config.label;
+            link.setAttribute("data-layer-ids", JSON.stringify(layerIds));
+            link.setAttribute("data-layer-type", config.type);
 
-        layers.forEach((layerId, index) => {
-          const link = document.createElement("a");
-          link.id = layerId;
-          link.href = "#";
-          link.textContent = layerId;
-
-          // Check if the layer visibility is set to "none" initially
-          const initialVisibility = map.getLayoutProperty(
-            layerId,
-            "visibility",
-          );
-          link.className = initialVisibility === "none" ? "" : "active";
-
-          // Also hide any associated legends if the layer is initially hidden
-          if (initialVisibility === "none") {
-            const associatedLegends = document.querySelectorAll(
-              `.mapboxgl-legend[data-layer-id="${layerId}"]`,
-            );
-            associatedLegends.forEach((legend) => {
-              legend.style.display = "none";
-            });
-          }
-
-          link.onclick = function (e) {
-            const clickedLayer = this.textContent;
-            e.preventDefault();
-            e.stopPropagation();
-
-            const visibility = map.getLayoutProperty(
-              clickedLayer,
+            // Check if the first layer's visibility is set to "none" initially
+            const firstLayerId = layerIds[0];
+            const initialVisibility = map.getLayoutProperty(
+              firstLayerId,
               "visibility",
             );
+            link.className = initialVisibility === "none" ? "" : "active";
 
-            if (visibility === "visible") {
-              map.setLayoutProperty(clickedLayer, "visibility", "none");
-              this.className = "";
+            // Also hide any associated legends if the layer is initially hidden
+            if (initialVisibility === "none") {
+              layerIds.forEach(layerId => {
+                const associatedLegends = document.querySelectorAll(
+                  `.mapboxgl-legend[data-layer-id="${layerId}"]`,
+                );
+                associatedLegends.forEach((legend) => {
+                  legend.style.display = "none";
+                });
+              });
+            }
 
-              // Hide associated legends
+            // Show or hide layer(s) when the toggle is clicked
+            link.onclick = function (e) {
+              e.preventDefault();
+              e.stopPropagation();
+
+              const layerIds = JSON.parse(this.getAttribute("data-layer-ids"));
+              const firstLayerId = layerIds[0];
+              const visibility = map.getLayoutProperty(
+                firstLayerId,
+                "visibility",
+              );
+
+              // Toggle visibility for all layer IDs in the group
+              if (visibility === "visible") {
+                layerIds.forEach(layerId => {
+                  map.setLayoutProperty(layerId, "visibility", "none");
+                  // Hide associated legends
+                  const associatedLegends = document.querySelectorAll(
+                    `.mapboxgl-legend[data-layer-id="${layerId}"]`,
+                  );
+                  associatedLegends.forEach((legend) => {
+                    legend.style.display = "none";
+                  });
+                });
+                this.className = "";
+              } else {
+                layerIds.forEach(layerId => {
+                  map.setLayoutProperty(layerId, "visibility", "visible");
+                  // Show associated legends
+                  const associatedLegends = document.querySelectorAll(
+                    `.mapboxgl-legend[data-layer-id="${layerId}"]`,
+                  );
+                  associatedLegends.forEach((legend) => {
+                    legend.style.display = "";
+                  });
+                });
+                this.className = "active";
+              }
+            };
+
+            layersList.appendChild(link);
+          });
+        } else {
+          // Fallback to original behavior for simple layer arrays
+          // Ensure layers is always an array
+          if (!Array.isArray(layers)) {
+            layers = [layers];
+          }
+
+          layers.forEach((layerId, index) => {
+            const link = document.createElement("a");
+            link.id = layerId;
+            link.href = "#";
+            link.textContent = layerId;
+
+            // Check if the layer visibility is set to "none" initially
+            const initialVisibility = map.getLayoutProperty(
+              layerId,
+              "visibility",
+            );
+            link.className = initialVisibility === "none" ? "" : "active";
+
+            // Also hide any associated legends if the layer is initially hidden
+            if (initialVisibility === "none") {
               const associatedLegends = document.querySelectorAll(
-                `.mapboxgl-legend[data-layer-id="${clickedLayer}"]`,
+                `.mapboxgl-legend[data-layer-id="${layerId}"]`,
               );
               associatedLegends.forEach((legend) => {
                 legend.style.display = "none";
               });
-            } else {
-              this.className = "active";
-              map.setLayoutProperty(clickedLayer, "visibility", "visible");
-
-              // Show associated legends
-              const associatedLegends = document.querySelectorAll(
-                `.mapboxgl-legend[data-layer-id="${clickedLayer}"]`,
-              );
-              associatedLegends.forEach((legend) => {
-                legend.style.display = "";
-              });
             }
-          };
 
-          layersList.appendChild(link);
-        });
+            link.onclick = function (e) {
+              const clickedLayer = this.textContent;
+              e.preventDefault();
+              e.stopPropagation();
+
+              const visibility = map.getLayoutProperty(
+                clickedLayer,
+                "visibility",
+              );
+
+              if (visibility === "visible") {
+                map.setLayoutProperty(clickedLayer, "visibility", "none");
+                this.className = "";
+
+                // Hide associated legends
+                const associatedLegends = document.querySelectorAll(
+                  `.mapboxgl-legend[data-layer-id="${clickedLayer}"]`,
+                );
+                associatedLegends.forEach((legend) => {
+                  legend.style.display = "none";
+                });
+              } else {
+                this.className = "active";
+                map.setLayoutProperty(clickedLayer, "visibility", "visible");
+
+                // Show associated legends
+                const associatedLegends = document.querySelectorAll(
+                  `.mapboxgl-legend[data-layer-id="${clickedLayer}"]`,
+                );
+                associatedLegends.forEach((legend) => {
+                  legend.style.display = "";
+                });
+              }
+            };
+
+            layersList.appendChild(link);
+          });
+        }
 
         if (message.collapsible) {
           const toggleButton = document.createElement("div");

--- a/inst/htmlwidgets/mapboxgl.yaml
+++ b/inst/htmlwidgets/mapboxgl.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: mapbox-gl-js
-    version: "3.12.0"
+    version: "3.14.0"
     src:
       href: "https://api.mapbox.com/mapbox-gl-js/v3.12.0/"
     script:

--- a/inst/htmlwidgets/mapboxgl_compare.js
+++ b/inst/htmlwidgets/mapboxgl_compare.js
@@ -2797,37 +2797,89 @@ HTMLWidgets.widget({
             let layers =
               mapData.layers_control.layers ||
               map.getStyle().layers.map((layer) => layer.id);
+            let layersConfig = mapData.layers_control.layers_config;
 
-            layers.forEach((layerId, index) => {
-              const link = document.createElement("a");
-              link.id = layerId;
-              link.href = "#";
-              link.textContent = layerId;
-              link.className = "active";
+            // If we have a layers_config, use that; otherwise fall back to original behavior
+            if (layersConfig && Array.isArray(layersConfig)) {
+              layersConfig.forEach((config, index) => {
+                const link = document.createElement("a");
+                // Ensure config.ids is always an array
+                const layerIds = Array.isArray(config.ids) ? config.ids : [config.ids];
+                link.id = layerIds.join("-");
+                link.href = "#";
+                link.textContent = config.label;
+                link.setAttribute("data-layer-ids", JSON.stringify(layerIds));
+                link.setAttribute("data-layer-type", config.type);
 
-              // Show or hide layer when the toggle is clicked
-              link.onclick = function (e) {
-                const clickedLayer = this.textContent;
-                e.preventDefault();
-                e.stopPropagation();
-
-                const visibility = map.getLayoutProperty(
-                  clickedLayer,
+                // Check if the first layer's visibility is set to "none" initially
+                const firstLayerId = layerIds[0];
+                const initialVisibility = map.getLayoutProperty(
+                  firstLayerId,
                   "visibility",
                 );
+                link.className = initialVisibility === "none" ? "" : "active";
 
-                // Toggle layer visibility by changing the layout object's visibility property
-                if (visibility === "visible") {
-                  map.setLayoutProperty(clickedLayer, "visibility", "none");
-                  this.className = "";
-                } else {
-                  this.className = "active";
-                  map.setLayoutProperty(clickedLayer, "visibility", "visible");
-                }
-              };
+                // Show or hide layer(s) when the toggle is clicked
+                link.onclick = function (e) {
+                  e.preventDefault();
+                  e.stopPropagation();
 
-              layersList.appendChild(link);
-            });
+                  const layerIds = JSON.parse(this.getAttribute("data-layer-ids"));
+                  const firstLayerId = layerIds[0];
+                  const visibility = map.getLayoutProperty(
+                    firstLayerId,
+                    "visibility",
+                  );
+
+                  // Toggle visibility for all layer IDs in the group
+                  if (visibility === "visible") {
+                    layerIds.forEach(layerId => {
+                      map.setLayoutProperty(layerId, "visibility", "none");
+                    });
+                    this.className = "";
+                  } else {
+                    layerIds.forEach(layerId => {
+                      map.setLayoutProperty(layerId, "visibility", "visible");
+                    });
+                    this.className = "active";
+                  }
+                };
+
+                layersList.appendChild(link);
+              });
+            } else {
+              // Fallback to original behavior for simple layer arrays
+              layers.forEach((layerId, index) => {
+                const link = document.createElement("a");
+                link.id = layerId;
+                link.href = "#";
+                link.textContent = layerId;
+                link.className = "active";
+
+                // Show or hide layer when the toggle is clicked
+                link.onclick = function (e) {
+                  const clickedLayer = this.textContent;
+                  e.preventDefault();
+                  e.stopPropagation();
+
+                  const visibility = map.getLayoutProperty(
+                    clickedLayer,
+                    "visibility",
+                  );
+
+                  // Toggle layer visibility by changing the layout object's visibility property
+                  if (visibility === "visible") {
+                    map.setLayoutProperty(clickedLayer, "visibility", "none");
+                    this.className = "";
+                  } else {
+                    this.className = "active";
+                    map.setLayoutProperty(clickedLayer, "visibility", "visible");
+                  }
+                };
+
+                layersList.appendChild(link);
+              });
+            }
 
             // Handle collapsible behavior
             if (mapData.layers_control.collapsible) {

--- a/inst/htmlwidgets/mapboxgl_compare.yaml
+++ b/inst/htmlwidgets/mapboxgl_compare.yaml
@@ -1,13 +1,13 @@
 dependencies:
   - name: mapbox-gl-js
-    version: "3.12.0"
+    version: "3.14.0"
     src:
       href: "https://api.mapbox.com/mapbox-gl-js/"
     script:
-      - "v3.12.0/mapbox-gl.js"
+      - "v3.14.0/mapbox-gl.js"
       - "plugins/mapbox-gl-compare/v0.4.0/mapbox-gl-compare.js"
     stylesheet:
-      - "v3.12.0/mapbox-gl.css"
+      - "v3.14.0/mapbox-gl.css"
       - "plugins/mapbox-gl-compare/v0.4.0/mapbox-gl-compare.css"
   - name: mapbox-gl-draw
     version: "1.4.3"

--- a/inst/htmlwidgets/maplibregl.js
+++ b/inst/htmlwidgets/maplibregl.js
@@ -1394,74 +1394,152 @@ HTMLWidgets.widget({
             let layers =
               x.layers_control.layers ||
               map.getStyle().layers.map((layer) => layer.id);
+            let layersConfig = x.layers_control.layers_config;
 
-            // Ensure layers is always an array
-            if (!Array.isArray(layers)) {
-              layers = [layers];
-            }
+            // If we have a layers_config, use that; otherwise fall back to original behavior
+            if (layersConfig && Array.isArray(layersConfig)) {
+              layersConfig.forEach((config, index) => {
+                const link = document.createElement("a");
+                // Ensure config.ids is always an array
+                const layerIds = Array.isArray(config.ids) ? config.ids : [config.ids];
+                link.id = layerIds.join("-");
+                link.href = "#";
+                link.textContent = config.label;
+                link.setAttribute("data-layer-ids", JSON.stringify(layerIds));
+                link.setAttribute("data-layer-type", config.type);
 
-            layers.forEach((layerId, index) => {
-              const link = document.createElement("a");
-              link.id = layerId;
-              link.href = "#";
-              link.textContent = layerId;
-
-              // Check if the layer visibility is set to "none" initially
-              const initialVisibility = map.getLayoutProperty(
-                layerId,
-                "visibility",
-              );
-              link.className = initialVisibility === "none" ? "" : "active";
-
-              // Also hide any associated legends if the layer is initially hidden
-              if (initialVisibility === "none") {
-                const associatedLegends = document.querySelectorAll(
-                  `.mapboxgl-legend[data-layer-id="${layerId}"]`,
-                );
-                associatedLegends.forEach((legend) => {
-                  legend.style.display = "none";
-                });
-              }
-
-              // Show or hide layer when the toggle is clicked
-              link.onclick = function (e) {
-                const clickedLayer = this.textContent;
-                e.preventDefault();
-                e.stopPropagation();
-
-                const visibility = map.getLayoutProperty(
-                  clickedLayer,
+                // Check if the first layer's visibility is set to "none" initially
+                const firstLayerId = layerIds[0];
+                const initialVisibility = map.getLayoutProperty(
+                  firstLayerId,
                   "visibility",
                 );
+                link.className = initialVisibility === "none" ? "" : "active";
 
-                // Toggle layer visibility by changing the layout object's visibility property
-                if (visibility === "visible") {
-                  map.setLayoutProperty(clickedLayer, "visibility", "none");
-                  this.className = "";
+                // Also hide any associated legends if the layer is initially hidden
+                if (initialVisibility === "none") {
+                  layerIds.forEach(layerId => {
+                    const associatedLegends = document.querySelectorAll(
+                      `.mapboxgl-legend[data-layer-id="${layerId}"]`,
+                    );
+                    associatedLegends.forEach((legend) => {
+                      legend.style.display = "none";
+                    });
+                  });
+                }
 
-                  // Hide associated legends
+                // Show or hide layer(s) when the toggle is clicked
+                link.onclick = function (e) {
+                  e.preventDefault();
+                  e.stopPropagation();
+
+                  const layerIds = JSON.parse(this.getAttribute("data-layer-ids"));
+                  const firstLayerId = layerIds[0];
+                  const visibility = map.getLayoutProperty(
+                    firstLayerId,
+                    "visibility",
+                  );
+
+                  // Toggle visibility for all layer IDs in the group
+                  if (visibility === "visible") {
+                    layerIds.forEach(layerId => {
+                      map.setLayoutProperty(layerId, "visibility", "none");
+                      // Hide associated legends
+                      const associatedLegends = document.querySelectorAll(
+                        `.mapboxgl-legend[data-layer-id="${layerId}"]`,
+                      );
+                      associatedLegends.forEach((legend) => {
+                        legend.style.display = "none";
+                      });
+                    });
+                    this.className = "";
+                  } else {
+                    layerIds.forEach(layerId => {
+                      map.setLayoutProperty(layerId, "visibility", "visible");
+                      // Show associated legends
+                      const associatedLegends = document.querySelectorAll(
+                        `.mapboxgl-legend[data-layer-id="${layerId}"]`,
+                      );
+                      associatedLegends.forEach((legend) => {
+                        legend.style.display = "";
+                      });
+                    });
+                    this.className = "active";
+                  }
+                };
+
+                layersList.appendChild(link);
+              });
+            } else {
+              // Fallback to original behavior for simple layer arrays
+              // Ensure layers is always an array
+              if (!Array.isArray(layers)) {
+                layers = [layers];
+              }
+
+              layers.forEach((layerId, index) => {
+                const link = document.createElement("a");
+                link.id = layerId;
+                link.href = "#";
+                link.textContent = layerId;
+
+                // Check if the layer visibility is set to "none" initially
+                const initialVisibility = map.getLayoutProperty(
+                  layerId,
+                  "visibility",
+                );
+                link.className = initialVisibility === "none" ? "" : "active";
+
+                // Also hide any associated legends if the layer is initially hidden
+                if (initialVisibility === "none") {
                   const associatedLegends = document.querySelectorAll(
-                    `.mapboxgl-legend[data-layer-id="${clickedLayer}"]`,
+                    `.mapboxgl-legend[data-layer-id="${layerId}"]`,
                   );
                   associatedLegends.forEach((legend) => {
                     legend.style.display = "none";
                   });
-                } else {
-                  this.className = "active";
-                  map.setLayoutProperty(clickedLayer, "visibility", "visible");
-
-                  // Show associated legends
-                  const associatedLegends = document.querySelectorAll(
-                    `.mapboxgl-legend[data-layer-id="${clickedLayer}"]`,
-                  );
-                  associatedLegends.forEach((legend) => {
-                    legend.style.display = "";
-                  });
                 }
-              };
 
-              layersList.appendChild(link);
-            });
+                // Show or hide layer when the toggle is clicked
+                link.onclick = function (e) {
+                  const clickedLayer = this.textContent;
+                  e.preventDefault();
+                  e.stopPropagation();
+
+                  const visibility = map.getLayoutProperty(
+                    clickedLayer,
+                    "visibility",
+                  );
+
+                  // Toggle layer visibility by changing the layout object's visibility property
+                  if (visibility === "visible") {
+                    map.setLayoutProperty(clickedLayer, "visibility", "none");
+                    this.className = "";
+
+                    // Hide associated legends
+                    const associatedLegends = document.querySelectorAll(
+                      `.mapboxgl-legend[data-layer-id="${clickedLayer}"]`,
+                    );
+                    associatedLegends.forEach((legend) => {
+                      legend.style.display = "none";
+                    });
+                  } else {
+                    this.className = "active";
+                    map.setLayoutProperty(clickedLayer, "visibility", "visible");
+
+                    // Show associated legends
+                    const associatedLegends = document.querySelectorAll(
+                      `.mapboxgl-legend[data-layer-id="${clickedLayer}"]`,
+                    );
+                    associatedLegends.forEach((legend) => {
+                      legend.style.display = "";
+                    });
+                  }
+                };
+
+                layersList.appendChild(link);
+              });
+            }
 
             // Handle collapsible behavior
             if (x.layers_control.collapsible) {
@@ -3962,43 +4040,120 @@ if (HTMLWidgets.shinyMode) {
         layersControl.appendChild(layersList);
 
         let layers = message.layers || [];
+        let layersConfig = message.layers_config;
 
-        // Ensure layers is always an array
-        if (!Array.isArray(layers)) {
-          layers = [layers];
-        }
+        // If we have a layers_config, use that; otherwise fall back to original behavior
+        if (layersConfig && Array.isArray(layersConfig)) {
+          layersConfig.forEach((config, index) => {
+            const link = document.createElement("a");
+            // Ensure config.ids is always an array
+            const layerIds = Array.isArray(config.ids) ? config.ids : [config.ids];
+            link.id = layerIds.join("-");
+            link.href = "#";
+            link.textContent = config.label;
+            link.setAttribute("data-layer-ids", JSON.stringify(layerIds));
+            link.setAttribute("data-layer-type", config.type);
 
-        layers.forEach((layerId, index) => {
-          const link = document.createElement("a");
-          link.id = layerId;
-          link.href = "#";
-          link.textContent = layerId;
-
-          // Check if the layer visibility is set to "none" initially
-          const initialVisibility = map.getLayoutProperty(
-            layerId,
-            "visibility",
-          );
-          link.className = initialVisibility === "none" ? "" : "active";
-
-          // Also hide any associated legends if the layer is initially hidden
-          if (initialVisibility === "none") {
-            const associatedLegends = document.querySelectorAll(
-              `.mapboxgl-legend[data-layer-id="${layerId}"]`,
+            // Check if the first layer's visibility is set to "none" initially
+            const firstLayerId = layerIds[0];
+            const initialVisibility = map.getLayoutProperty(
+              firstLayerId,
+              "visibility",
             );
-            associatedLegends.forEach((legend) => {
-              legend.style.display = "none";
-            });
+            link.className = initialVisibility === "none" ? "" : "active";
+
+            // Also hide any associated legends if the layer is initially hidden
+            if (initialVisibility === "none") {
+              layerIds.forEach(layerId => {
+                const associatedLegends = document.querySelectorAll(
+                  `.mapboxgl-legend[data-layer-id="${layerId}"]`,
+                );
+                associatedLegends.forEach((legend) => {
+                  legend.style.display = "none";
+                });
+              });
+            }
+
+            // Show or hide layer(s) when the toggle is clicked
+            link.onclick = function (e) {
+              e.preventDefault();
+              e.stopPropagation();
+
+              const layerIds = JSON.parse(this.getAttribute("data-layer-ids"));
+              const firstLayerId = layerIds[0];
+              const visibility = map.getLayoutProperty(
+                firstLayerId,
+                "visibility",
+              );
+
+              // Toggle visibility for all layer IDs in the group
+              if (visibility === "visible") {
+                layerIds.forEach(layerId => {
+                  map.setLayoutProperty(layerId, "visibility", "none");
+                  // Hide associated legends
+                  const associatedLegends = document.querySelectorAll(
+                    `.mapboxgl-legend[data-layer-id="${layerId}"]`,
+                  );
+                  associatedLegends.forEach((legend) => {
+                    legend.style.display = "none";
+                  });
+                });
+                this.className = "";
+              } else {
+                layerIds.forEach(layerId => {
+                  map.setLayoutProperty(layerId, "visibility", "visible");
+                  // Show associated legends
+                  const associatedLegends = document.querySelectorAll(
+                    `.mapboxgl-legend[data-layer-id="${layerId}"]`,
+                  );
+                  associatedLegends.forEach((legend) => {
+                    legend.style.display = "";
+                  });
+                });
+                this.className = "active";
+              }
+            };
+
+            layersList.appendChild(link);
+          });
+        } else {
+          // Fallback to original behavior for simple layer arrays
+          // Ensure layers is always an array
+          if (!Array.isArray(layers)) {
+            layers = [layers];
           }
 
-          link.onclick = function (e) {
-            const clickedLayer = this.textContent;
-            e.preventDefault();
-            e.stopPropagation();
+          layers.forEach((layerId, index) => {
+            const link = document.createElement("a");
+            link.id = layerId;
+            link.href = "#";
+            link.textContent = layerId;
 
-            const visibility = map.getLayoutProperty(
-              clickedLayer,
+            // Check if the layer visibility is set to "none" initially
+            const initialVisibility = map.getLayoutProperty(
+              layerId,
               "visibility",
+            );
+            link.className = initialVisibility === "none" ? "" : "active";
+
+            // Also hide any associated legends if the layer is initially hidden
+            if (initialVisibility === "none") {
+              const associatedLegends = document.querySelectorAll(
+                `.mapboxgl-legend[data-layer-id="${layerId}"]`,
+              );
+              associatedLegends.forEach((legend) => {
+                legend.style.display = "none";
+              });
+            }
+
+            link.onclick = function (e) {
+              const clickedLayer = this.textContent;
+              e.preventDefault();
+              e.stopPropagation();
+
+              const visibility = map.getLayoutProperty(
+                clickedLayer,
+                "visibility",
             );
 
             if (visibility === "visible") {
@@ -4028,6 +4183,7 @@ if (HTMLWidgets.shinyMode) {
 
           layersList.appendChild(link);
         });
+        }
 
         if (message.collapsible) {
           const toggleButton = document.createElement("div");

--- a/inst/htmlwidgets/maplibregl_compare.js
+++ b/inst/htmlwidgets/maplibregl_compare.js
@@ -3805,45 +3805,97 @@ HTMLWidgets.widget({
                         let layers =
                             mapData.layers_control.layers ||
                             map.getStyle().layers.map((layer) => layer.id);
+                        let layersConfig = mapData.layers_control.layers_config;
 
-                        layers.forEach((layerId, index) => {
-                            const link = document.createElement("a");
-                            link.id = layerId;
-                            link.href = "#";
-                            link.textContent = layerId;
-                            link.className = "active";
+                        // If we have a layers_config, use that; otherwise fall back to original behavior
+                        if (layersConfig && Array.isArray(layersConfig)) {
+                            layersConfig.forEach((config, index) => {
+                                const link = document.createElement("a");
+                                // Ensure config.ids is always an array
+                                const layerIds = Array.isArray(config.ids) ? config.ids : [config.ids];
+                                link.id = layerIds.join("-");
+                                link.href = "#";
+                                link.textContent = config.label;
+                                link.setAttribute("data-layer-ids", JSON.stringify(layerIds));
+                                link.setAttribute("data-layer-type", config.type);
 
-                            // Show or hide layer when the toggle is clicked
-                            link.onclick = function (e) {
-                                const clickedLayer = this.textContent;
-                                e.preventDefault();
-                                e.stopPropagation();
-
-                                const visibility = map.getLayoutProperty(
-                                    clickedLayer,
+                                // Check if the first layer's visibility is set to "none" initially
+                                const firstLayerId = layerIds[0];
+                                const initialVisibility = map.getLayoutProperty(
+                                    firstLayerId,
                                     "visibility",
                                 );
+                                link.className = initialVisibility === "none" ? "" : "active";
 
-                                // Toggle layer visibility by changing the layout object's visibility property
-                                if (visibility === "visible") {
-                                    map.setLayoutProperty(
+                                // Show or hide layer(s) when the toggle is clicked
+                                link.onclick = function (e) {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+
+                                    const layerIds = JSON.parse(this.getAttribute("data-layer-ids"));
+                                    const firstLayerId = layerIds[0];
+                                    const visibility = map.getLayoutProperty(
+                                        firstLayerId,
+                                        "visibility",
+                                    );
+
+                                    // Toggle visibility for all layer IDs in the group
+                                    if (visibility === "visible") {
+                                        layerIds.forEach(layerId => {
+                                            map.setLayoutProperty(layerId, "visibility", "none");
+                                        });
+                                        this.className = "";
+                                    } else {
+                                        layerIds.forEach(layerId => {
+                                            map.setLayoutProperty(layerId, "visibility", "visible");
+                                        });
+                                        this.className = "active";
+                                    }
+                                };
+
+                                layersList.appendChild(link);
+                            });
+                        } else {
+                            // Fallback to original behavior for simple layer arrays
+                            layers.forEach((layerId, index) => {
+                                const link = document.createElement("a");
+                                link.id = layerId;
+                                link.href = "#";
+                                link.textContent = layerId;
+                                link.className = "active";
+
+                                // Show or hide layer when the toggle is clicked
+                                link.onclick = function (e) {
+                                    const clickedLayer = this.textContent;
+                                    e.preventDefault();
+                                    e.stopPropagation();
+
+                                    const visibility = map.getLayoutProperty(
                                         clickedLayer,
                                         "visibility",
-                                        "none",
                                     );
-                                    this.className = "";
-                                } else {
-                                    this.className = "active";
-                                    map.setLayoutProperty(
-                                        clickedLayer,
-                                        "visibility",
-                                        "visible",
-                                    );
-                                }
-                            };
 
-                            layersList.appendChild(link);
-                        });
+                                    // Toggle layer visibility by changing the layout object's visibility property
+                                    if (visibility === "visible") {
+                                        map.setLayoutProperty(
+                                            clickedLayer,
+                                            "visibility",
+                                            "none",
+                                        );
+                                        this.className = "";
+                                    } else {
+                                        this.className = "active";
+                                        map.setLayoutProperty(
+                                            clickedLayer,
+                                            "visibility",
+                                            "visible",
+                                        );
+                                    }
+                                };
+
+                                layersList.appendChild(link);
+                            });
+                        }
 
                         // Handle collapsible behavior
                         if (mapData.layers_control.collapsible) {

--- a/man/add_layers_control.Rd
+++ b/man/add_layers_control.Rd
@@ -26,7 +26,10 @@ add_layers_control(
 
 \item{position}{The position of the control on the map (one of "top-left", "top-right", "bottom-left", "bottom-right").}
 
-\item{layers}{A vector of layer IDs to be included in the control. If NULL, all layers will be included.}
+\item{layers}{Either a character vector of layer IDs to include in the control,
+a named list/vector where names are labels and values are layer IDs,
+or a named list where values can be vectors to group multiple layers together.
+If NULL, all layers will be included.}
 
 \item{collapsible}{Whether the control should be collapsible.}
 
@@ -84,12 +87,26 @@ maplibre() |>
         active_color = "#4a90e2"
     )
 
-# Avoid collision with other controls using margin parameters
+# With custom labels
 maplibre() |>
-    add_navigation_control(position = "top-right") |>
+    add_fill_layer(id = "tract-fill", source = tr) |>
+    add_line_layer(id = "tract-line", source = tr) |>
     add_layers_control(
-        position = "top-right",
-        margin_top = 110
+        layers = list(
+            "Census Tracts" = "tract-fill",
+            "Tract Borders" = "tract-line"
+        )
+    )
+
+# Group multiple layers together
+maplibre() |>
+    add_fill_layer(id = "county-fill", source = counties) |>
+    add_line_layer(id = "county-outline", source = counties) |>
+    add_layers_control(
+        layers = list(
+            "Counties" = c("county-fill", "county-outline"),
+            "Roads" = "roads-layer"
+        )
     )
 }
 }

--- a/man/add_layers_control.Rd
+++ b/man/add_layers_control.Rd
@@ -67,6 +67,7 @@ options(tigris_use_cache = TRUE)
 
 rds <- roads("TX", "Tarrant")
 tr <- tracts("TX", "Tarrant", cb = TRUE)
+cty <- counties("TX", cb = TRUE)
 
 maplibre() |>
     fit_bounds(rds) |>
@@ -99,9 +100,19 @@ maplibre() |>
     )
 
 # Group multiple layers together
-maplibre() |>
-    add_fill_layer(id = "county-fill", source = counties) |>
-    add_line_layer(id = "county-outline", source = counties) |>
+maplibre(bounds = cty) |>
+    add_fill_layer(id = "county-fill", source = cty, fill_opacity = 0.3) |>
+    add_line_layer(
+        id = "county-outline",
+        source = cty,
+        line_color = "yellow",
+        line_width = 3
+    ) |>
+    add_line_layer(
+        id = "roads-layer",
+        source = rds,
+        line_color = "blue"
+    ) |>
     add_layers_control(
         layers = list(
             "Counties" = c("county-fill", "county-outline"),


### PR DESCRIPTION
This PR allows users to supply custom labels for layers to the layers control (as a named list), and to group layers together within that list as a vector.  Example: 

```r
library(tigris)
options(tigris_use_cache = TRUE)

rds <- roads("TX", "Tarrant")
tr <- tracts("TX", "Tarrant", cb = TRUE)
cty <- counties("TX", cb = TRUE)

maplibre(bounds = cty) |>
    add_fill_layer(id = "county-fill", source = cty, fill_opacity = 0.3) |>
    add_line_layer(
        id = "county-outline",
        source = cty,
        line_color = "yellow",
        line_width = 3
    ) |>
    add_line_layer(
        id = "roads-layer",
        source = rds,
        line_color = "blue"
    ) |>
    add_layers_control(
        layers = list(
            "Counties" = c("county-fill", "county-outline"),
            "Roads" = "roads-layer"
        )
    )
```

@mtennekes I know you had asked about this, I think this should work!