### PR TITLE
Handle conflicting tooltips / popups intelligently

### DIFF
--- a/inst/htmlwidgets/mapboxgl_compare.js
+++ b/inst/htmlwidgets/mapboxgl_compare.js
@@ -60,32 +60,59 @@ function evaluateExpression(expression, properties) {
   }
 }
 
-function onMouseMoveTooltip(e, map, tooltipPopup, tooltipProperty) {
-  map.getCanvas().style.cursor = "pointer";
+function onMouseMoveTooltip(e, map, tooltipPopup, tooltipProperty, layerId) {
   if (e.features.length > 0) {
-    // Clear any existing active tooltip first to prevent stacking
-    if (window._activeTooltip && window._activeTooltip !== tooltipPopup) {
-      window._activeTooltip.remove();
+    // Query all features at this point to determine z-order
+    // Features are returned in top-to-bottom rendering order
+    const allFeatures = map.queryRenderedFeatures(e.point);
+
+    // Find the topmost layer that has a tooltip
+    let topmostLayerWithTooltip = null;
+    for (let i = 0; i < allFeatures.length; i++) {
+      const feature = allFeatures[i];
+      const featureLayerId = feature.layer.id;
+
+      // Check if this layer has a tooltip handler registered
+      if (window._mapboxHandlers && window._mapboxHandlers[featureLayerId]) {
+        topmostLayerWithTooltip = featureLayerId;
+        break;
+      }
     }
 
-    let description;
+    // Only show tooltip if this is the topmost layer with a tooltip
+    if (topmostLayerWithTooltip === layerId) {
+      map.getCanvas().style.cursor = "pointer";
 
-    // Check if tooltipProperty is an expression (array) or a simple property name (string)
-    if (Array.isArray(tooltipProperty)) {
-      // It's an expression, evaluate it
-      description = evaluateExpression(
-        tooltipProperty,
-        e.features[0].properties,
-      );
+      // Clear any existing active tooltip first to prevent stacking
+      if (window._activeTooltip && window._activeTooltip !== tooltipPopup) {
+        window._activeTooltip.remove();
+      }
+
+      let description;
+
+      // Check if tooltipProperty is an expression (array) or a simple property name (string)
+      if (Array.isArray(tooltipProperty)) {
+        // It's an expression, evaluate it
+        description = evaluateExpression(
+          tooltipProperty,
+          e.features[0].properties,
+        );
+      } else {
+        // It's a property name, get the value
+        description = e.features[0].properties[tooltipProperty];
+      }
+
+      tooltipPopup.setLngLat(e.lngLat).setHTML(description).addTo(map);
+
+      // Store reference to currently active tooltip
+      window._activeTooltip = tooltipPopup;
     } else {
-      // It's a property name, get the value
-      description = e.features[0].properties[tooltipProperty];
+      // This layer is not topmost, hide tooltip if it was showing
+      tooltipPopup.remove();
+      if (window._activeTooltip === tooltipPopup) {
+        delete window._activeTooltip;
+      }
     }
-
-    tooltipPopup.setLngLat(e.lngLat).setHTML(description).addTo(map);
-
-    // Store reference to currently active tooltip
-    window._activeTooltip = tooltipPopup;
   } else {
     tooltipPopup.remove();
     // If this was the active tooltip, clear the reference
@@ -104,40 +131,67 @@ function onMouseLeaveTooltip(map, tooltipPopup) {
 }
 
 function onClickPopup(e, map, popupProperty, layerId) {
-  let description;
+  if (e.features.length > 0) {
+    // Query all features at this point to determine z-order
+    const allFeatures = map.queryRenderedFeatures(e.point);
 
-  // Check if popupProperty is an expression (array) or a simple property name (string)
-  if (Array.isArray(popupProperty)) {
-    // It's an expression, evaluate it
-    description = evaluateExpression(popupProperty, e.features[0].properties);
-  } else {
-    // It's a property name, get the value
-    description = e.features[0].properties[popupProperty];
-  }
+    // Find the topmost layer that has a popup
+    let topmostLayerWithPopup = null;
+    for (let i = 0; i < allFeatures.length; i++) {
+      const feature = allFeatures[i];
+      const featureLayerId = feature.layer.id;
 
-  // Remove any existing popup for this layer
-  if (window._mapboxPopups && window._mapboxPopups[layerId]) {
-    window._mapboxPopups[layerId].remove();
-  }
-
-  // Create and show the popup
-  const popup = new mapboxgl.Popup({ maxWidth: '400px' })
-    .setLngLat(e.lngLat)
-    .setHTML(description)
-    .addTo(map);
-
-  // Store reference to this popup
-  if (!window._mapboxPopups) {
-    window._mapboxPopups = {};
-  }
-  window._mapboxPopups[layerId] = popup;
-
-  // Remove reference when popup is closed
-  popup.on("close", function () {
-    if (window._mapboxPopups[layerId] === popup) {
-      delete window._mapboxPopups[layerId];
+      // Check if this layer has a popup handler registered
+      if (
+        window._mapboxClickHandlers &&
+        window._mapboxClickHandlers[featureLayerId]
+      ) {
+        topmostLayerWithPopup = featureLayerId;
+        break;
+      }
     }
-  });
+
+    // Only show popup if this is the topmost layer with a popup
+    if (topmostLayerWithPopup === layerId) {
+      let description;
+
+      // Check if popupProperty is an expression (array) or a simple property name (string)
+      if (Array.isArray(popupProperty)) {
+        // It's an expression, evaluate it
+        description = evaluateExpression(
+          popupProperty,
+          e.features[0].properties,
+        );
+      } else {
+        // It's a property name, get the value
+        description = e.features[0].properties[popupProperty];
+      }
+
+      // Remove any existing popup for this layer
+      if (window._mapboxPopups && window._mapboxPopups[layerId]) {
+        window._mapboxPopups[layerId].remove();
+      }
+
+      // Create and show the popup
+      const popup = new mapboxgl.Popup({ maxWidth: "400px" })
+        .setLngLat(e.lngLat)
+        .setHTML(description)
+        .addTo(map);
+
+      // Store reference to this popup
+      if (!window._mapboxPopups) {
+        window._mapboxPopups = {};
+      }
+      window._mapboxPopups[layerId] = popup;
+
+      // Remove reference when popup is closed
+      popup.on("close", function () {
+        if (window._mapboxPopups[layerId] === popup) {
+          delete window._mapboxPopups[layerId];
+        }
+      });
+    }
+  }
 }
 
 HTMLWidgets.widget({
@@ -159,11 +213,17 @@ HTMLWidgets.widget({
           console.error("Mapbox GL Compare plugin is not loaded.");
           return;
         }
-        
+
         // Register PMTiles source type if available
-        if (typeof MapboxPmTilesSource !== "undefined" && typeof pmtiles !== "undefined") {
+        if (
+          typeof MapboxPmTilesSource !== "undefined" &&
+          typeof pmtiles !== "undefined"
+        ) {
           try {
-            mapboxgl.Style.setSourceType(PMTILES_SOURCE_TYPE, MapboxPmTilesSource);
+            mapboxgl.Style.setSourceType(
+              PMTILES_SOURCE_TYPE,
+              MapboxPmTilesSource,
+            );
             console.log("PMTiles support enabled for Mapbox GL JS Compare");
           } catch (e) {
             console.warn("Failed to register PMTiles source type:", e);
@@ -325,21 +385,21 @@ HTMLWidgets.widget({
           if (HTMLWidgets.shinyMode) {
             setupShinyEvents(afterMap, el.id, "after");
           }
-          
+
           // Add compare-level legends after both maps are loaded
           if (x.compare_legends && Array.isArray(x.compare_legends)) {
-            x.compare_legends.forEach(function(legendInfo) {
+            x.compare_legends.forEach(function (legendInfo) {
               // Add CSS
               const legendCss = document.createElement("style");
               legendCss.innerHTML = legendInfo.css;
               legendCss.setAttribute("data-mapgl-legend-css", el.id);
               document.head.appendChild(legendCss);
-              
+
               // Create legend element
               const legend = document.createElement("div");
               legend.innerHTML = legendInfo.html;
               legend.classList.add("mapboxgl-legend");
-              
+
               // Append to the appropriate container based on target
               if (legendInfo.target === "compare") {
                 // Append to the main compare container
@@ -525,14 +585,14 @@ HTMLWidgets.widget({
                 } else {
                   // Handle custom source types (like pmtile-source)
                   const sourceConfig = { type: message.source.type };
-                  
+
                   // Copy all properties except id
                   Object.keys(message.source).forEach(function (key) {
                     if (key !== "id") {
                       sourceConfig[key] = message.source[key];
                     }
                   });
-                  
+
                   map.addSource(message.source.id, sourceConfig);
                 }
               } else if (message.type === "add_layer") {
@@ -585,7 +645,7 @@ HTMLWidgets.widget({
                     const tooltip = new mapboxgl.Popup({
                       closeButton: false,
                       closeOnClick: false,
-                      maxWidth: '400px',
+                      maxWidth: "400px",
                     });
 
                     // Define named handler functions:
@@ -595,6 +655,7 @@ HTMLWidgets.widget({
                         map,
                         tooltip,
                         message.layer.tooltip,
+                        message.layer.id,
                       );
                     };
 
@@ -856,7 +917,7 @@ HTMLWidgets.widget({
                 const legend = document.createElement("div");
                 legend.innerHTML = message.html;
                 legend.classList.add("mapboxgl-legend");
-                
+
                 // Append legend to the correct map container
                 const targetContainer = map.getContainer();
                 targetContainer.appendChild(legend);
@@ -1056,7 +1117,7 @@ HTMLWidgets.widget({
                           const tooltip = new mapboxgl.Popup({
                             closeButton: false,
                             closeOnClick: false,
-                            maxWidth: '400px',
+                            maxWidth: "400px",
                           });
 
                           map.on("mousemove", layerId, function (e) {
@@ -1065,6 +1126,7 @@ HTMLWidgets.widget({
                               map,
                               tooltip,
                               tooltipProperty,
+                              layerId,
                             );
                           });
 
@@ -1166,19 +1228,22 @@ HTMLWidgets.widget({
                 customControlContainer.innerHTML = controlOptions.html;
                 customControlContainer.className = "mapboxgl-ctrl";
                 if (controlOptions.className) {
-                  customControlContainer.className += " " + controlOptions.className;
+                  customControlContainer.className +=
+                    " " + controlOptions.className;
                 }
 
                 // Create the custom control object
                 const customControl = {
-                  onAdd: function(map) {
+                  onAdd: function (map) {
                     return customControlContainer;
                   },
-                  onRemove: function() {
+                  onRemove: function () {
                     if (customControlContainer.parentNode) {
-                      customControlContainer.parentNode.removeChild(customControlContainer);
+                      customControlContainer.parentNode.removeChild(
+                        customControlContainer,
+                      );
                     }
-                  }
+                  },
                 };
 
                 map.addControl(customControl, message.position);
@@ -1189,7 +1254,10 @@ HTMLWidgets.widget({
                 }
 
                 // Store control with proper type
-                map.controls.push({ type: message.control_id, control: customControl });
+                map.controls.push({
+                  type: message.control_id,
+                  control: customControl,
+                });
               } else if (message.type === "add_reset_control") {
                 const resetControl = document.createElement("button");
                 resetControl.className =
@@ -1299,9 +1367,11 @@ HTMLWidgets.widget({
 
                   // Update tooltip for freehand mode
                   setTimeout(() => {
-                    const polygonButton = map.getContainer().querySelector('.mapbox-gl-draw_polygon');
+                    const polygonButton = map
+                      .getContainer()
+                      .querySelector(".mapbox-gl-draw_polygon");
                     if (polygonButton) {
-                      polygonButton.title = 'Freehand polygon tool (p)';
+                      polygonButton.title = "Freehand polygon tool (p)";
                     }
                   }, 100);
                 }
@@ -1329,9 +1399,9 @@ HTMLWidgets.widget({
                 // Add download button if requested
                 if (message.download_button) {
                   // Add CSS for download button if not already added
-                  if (!document.querySelector('#mapgl-draw-download-styles')) {
-                    const style = document.createElement('style');
-                    style.id = 'mapgl-draw-download-styles';
+                  if (!document.querySelector("#mapgl-draw-download-styles")) {
+                    const style = document.createElement("style");
+                    style.id = "mapgl-draw-download-styles";
                     style.textContent = `
                       .mapbox-gl-draw_download {
                         background: transparent;
@@ -1359,46 +1429,56 @@ HTMLWidgets.widget({
                   // Small delay to ensure Draw control is fully rendered
                   setTimeout(() => {
                     // Find the Draw control button group
-                    const drawButtons = map.getContainer().querySelector('.mapboxgl-ctrl-group:has(.mapbox-gl-draw_polygon)');
-                    
+                    const drawButtons = map
+                      .getContainer()
+                      .querySelector(
+                        ".mapboxgl-ctrl-group:has(.mapbox-gl-draw_polygon)",
+                      );
+
                     if (drawButtons) {
                       // Create download button
-                      const downloadBtn = document.createElement('button');
-                      downloadBtn.className = 'mapbox-gl-draw_download';
-                      downloadBtn.title = 'Download drawn features as GeoJSON';
-                      
+                      const downloadBtn = document.createElement("button");
+                      downloadBtn.className = "mapbox-gl-draw_download";
+                      downloadBtn.title = "Download drawn features as GeoJSON";
+
                       // Add SVG download icon
                       downloadBtn.innerHTML = `
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                           <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/>
                         </svg>
                       `;
-                      
-                      downloadBtn.addEventListener('click', () => {
+
+                      downloadBtn.addEventListener("click", () => {
                         // Get all drawn features
-                        const data = map._mapgl_draw ? map._mapgl_draw.getAll() : null;
-                        
+                        const data = map._mapgl_draw
+                          ? map._mapgl_draw.getAll()
+                          : null;
+
                         if (data.features.length === 0) {
-                          alert('No features to download. Please draw something first!');
+                          alert(
+                            "No features to download. Please draw something first!",
+                          );
                           return;
                         }
-                        
+
                         // Convert to string with nice formatting
                         const dataStr = JSON.stringify(data, null, 2);
-                        
+
                         // Create blob and download
-                        const blob = new Blob([dataStr], { type: 'application/json' });
+                        const blob = new Blob([dataStr], {
+                          type: "application/json",
+                        });
                         const url = URL.createObjectURL(blob);
-                        
-                        const a = document.createElement('a');
+
+                        const a = document.createElement("a");
                         a.href = url;
-                        a.download = `${message.download_filename || 'drawn-features'}.geojson`;
+                        a.download = `${message.download_filename || "drawn-features"}.geojson`;
                         document.body.appendChild(a);
                         a.click();
                         document.body.removeChild(a);
                         URL.revokeObjectURL(url);
                       });
-                      
+
                       // Append to the Draw control button group
                       drawButtons.appendChild(downloadBtn);
                     }
@@ -1406,7 +1486,9 @@ HTMLWidgets.widget({
                 }
               } else if (message.type === "get_drawn_features") {
                 if (map._mapgl_draw) {
-                  const features = map._mapgl_draw ? map._mapgl_draw.getAll() : null;
+                  const features = map._mapgl_draw
+                    ? map._mapgl_draw.getAll()
+                    : null;
                   Shiny.setInputValue(
                     data.id + "_drawn_features",
                     JSON.stringify(features),
@@ -1453,7 +1535,7 @@ HTMLWidgets.widget({
                     mapMarker.setPopup(
                       new mapboxgl.Popup({
                         offset: 25,
-                        maxWidth: '400px',
+                        maxWidth: "400px",
                       }).setHTML(marker.popup),
                     );
                   }
@@ -1609,13 +1691,17 @@ HTMLWidgets.widget({
                   layersControl.style.left = (message.margin_left || 10) + "px";
                 } else if (position === "top-right") {
                   layersControl.style.top = (message.margin_top || 10) + "px";
-                  layersControl.style.right = (message.margin_right || 10) + "px";
+                  layersControl.style.right =
+                    (message.margin_right || 10) + "px";
                 } else if (position === "bottom-left") {
-                  layersControl.style.bottom = (message.margin_bottom || 30) + "px";
+                  layersControl.style.bottom =
+                    (message.margin_bottom || 30) + "px";
                   layersControl.style.left = (message.margin_left || 10) + "px";
                 } else if (position === "bottom-right") {
-                  layersControl.style.bottom = (message.margin_bottom || 40) + "px";
-                  layersControl.style.right = (message.margin_right || 10) + "px";
+                  layersControl.style.bottom =
+                    (message.margin_bottom || 40) + "px";
+                  layersControl.style.right =
+                    (message.margin_right || 10) + "px";
                 }
 
                 // Apply custom colors if provided
@@ -1770,7 +1856,7 @@ HTMLWidgets.widget({
                   const tooltip = new mapboxgl.Popup({
                     closeButton: false,
                     closeOnClick: false,
-                    maxWidth: '400px',
+                    maxWidth: "400px",
                   });
 
                   map.on("mousemove", message.layer, function (e) {
@@ -1876,7 +1962,10 @@ HTMLWidgets.widget({
 
                 let features;
                 if (message.geometry) {
-                  features = map.queryRenderedFeatures(message.geometry, queryOptions);
+                  features = map.queryRenderedFeatures(
+                    message.geometry,
+                    queryOptions,
+                  );
                 } else {
                   // No geometry specified - query entire viewport
                   features = map.queryRenderedFeatures(queryOptions);
@@ -1899,7 +1988,9 @@ HTMLWidgets.widget({
                 });
 
                 // Convert to GeoJSON FeatureCollection
-                const deduplicatedFeatures = Array.from(uniqueFeatures.values());
+                const deduplicatedFeatures = Array.from(
+                  uniqueFeatures.values(),
+                );
                 const featureCollection = {
                   type: "FeatureCollection",
                   features: deduplicatedFeatures,
@@ -1907,7 +1998,7 @@ HTMLWidgets.widget({
 
                 Shiny.setInputValue(
                   data.id + "_queried_features",
-                  JSON.stringify(featureCollection)
+                  JSON.stringify(featureCollection),
                 );
               } else if (message.type === "clear_controls") {
                 // Handle clear_controls for compare widgets
@@ -1964,35 +2055,43 @@ HTMLWidgets.widget({
             let isDrawing = false;
             if (map._mapgl_draw && map._mapgl_draw.getMode) {
               const mode = map._mapgl_draw.getMode();
-              isDrawing = mode === 'draw_point' ||
-                         mode === 'draw_line_string' ||
-                         mode === 'draw_polygon';
+              isDrawing =
+                mode === "draw_point" ||
+                mode === "draw_line_string" ||
+                mode === "draw_polygon";
             }
 
             // Only process feature clicks if not actively drawing
             if (!isDrawing) {
               const features = map.queryRenderedFeatures(e.point);
               // Filter out draw layers
-              const nonDrawFeatures = features.filter(feature =>
-                !feature.layer.id.includes('gl-draw') &&
-                !feature.source.includes('gl-draw')
+              const nonDrawFeatures = features.filter(
+                (feature) =>
+                  !feature.layer.id.includes("gl-draw") &&
+                  !feature.source.includes("gl-draw"),
               );
 
               if (nonDrawFeatures.length > 0) {
                 const feature = nonDrawFeatures[0];
                 if (window.Shiny) {
-                  Shiny.setInputValue(parentId + "_" + mapType + "_feature_click", {
-                    id: feature.id,
-                    properties: feature.properties,
-                    layer: feature.layer.id,
-                    lng: e.lngLat.lng,
-                    lat: e.lngLat.lat,
-                    time: Date.now(),
-                  });
+                  Shiny.setInputValue(
+                    parentId + "_" + mapType + "_feature_click",
+                    {
+                      id: feature.id,
+                      properties: feature.properties,
+                      layer: feature.layer.id,
+                      lng: e.lngLat.lng,
+                      lat: e.lngLat.lat,
+                      time: Date.now(),
+                    },
+                  );
                 }
               } else {
                 if (window.Shiny) {
-                  Shiny.setInputValue(parentId + "_" + mapType + "_feature_click", null);
+                  Shiny.setInputValue(
+                    parentId + "_" + mapType + "_feature_click",
+                    null,
+                  );
                 }
               }
             }
@@ -2008,20 +2107,24 @@ HTMLWidgets.widget({
           });
 
           // Add hover events if enabled for this map
-          const mapConfig = (mapType === "before") ? x.map1 : x.map2;
+          const mapConfig = mapType === "before" ? x.map1 : x.map2;
           if (mapConfig.hover_events && mapConfig.hover_events.enabled) {
             map.on("mousemove", function (e) {
               if (window.Shiny) {
                 // Feature hover events
                 if (mapConfig.hover_events.features) {
                   const options = mapConfig.hover_events.layer_id
-                    ? { layers: Array.isArray(mapConfig.hover_events.layer_id) 
-                        ? mapConfig.hover_events.layer_id 
-                        : mapConfig.hover_events.layer_id.split(',').map(id => id.trim()) }
+                    ? {
+                        layers: Array.isArray(mapConfig.hover_events.layer_id)
+                          ? mapConfig.hover_events.layer_id
+                          : mapConfig.hover_events.layer_id
+                              .split(",")
+                              .map((id) => id.trim()),
+                      }
                     : undefined;
                   const features = map.queryRenderedFeatures(e.point, options);
 
-                  if(features.length > 0) {
+                  if (features.length > 0) {
                     const feature = features[0];
                     Shiny.setInputValue(
                       parentId + "_" + mapType + "_feature_hover",
@@ -2032,26 +2135,23 @@ HTMLWidgets.widget({
                         lng: e.lngLat.lng,
                         lat: e.lngLat.lat,
                         time: new Date(),
-                      }
+                      },
                     );
                   } else {
                     Shiny.setInputValue(
                       parentId + "_" + mapType + "_feature_hover",
-                      null
+                      null,
                     );
                   }
                 }
 
                 // Coordinate hover events
                 if (mapConfig.hover_events.coordinates) {
-                  Shiny.setInputValue(
-                    parentId + "_" + mapType + "_hover",
-                    {
-                      lng: e.lngLat.lng,
-                      lat: e.lngLat.lat,
-                      time: new Date(),
-                    }
-                  );
+                  Shiny.setInputValue(parentId + "_" + mapType + "_hover", {
+                    lng: e.lngLat.lng,
+                    lat: e.lngLat.lat,
+                    time: new Date(),
+                  });
                 }
               }
             });
@@ -2102,7 +2202,9 @@ HTMLWidgets.widget({
 
               if (marker.popup) {
                 mapMarker.setPopup(
-                  new mapboxgl.Popup({ offset: 25, maxWidth: '400px' }).setText(marker.popup),
+                  new mapboxgl.Popup({ offset: 25, maxWidth: "400px" }).setText(
+                    marker.popup,
+                  ),
                 );
               }
 
@@ -2246,7 +2348,7 @@ HTMLWidgets.widget({
                   map.on("click", layer.id, function (e) {
                     const description = e.features[0].properties[layer.popup];
 
-                    new mapboxgl.Popup({ maxWidth: '400px' })
+                    new mapboxgl.Popup({ maxWidth: "400px" })
                       .setLngLat(e.lngLat)
                       .setHTML(description)
                       .addTo(map);
@@ -2257,12 +2359,18 @@ HTMLWidgets.widget({
                   const tooltip = new mapboxgl.Popup({
                     closeButton: false,
                     closeOnClick: false,
-                    maxWidth: '400px',
+                    maxWidth: "400px",
                   });
 
                   // Create a reference to the mousemove handler function
                   const mouseMoveHandler = function (e) {
-                    onMouseMoveTooltip(e, map, tooltip, layer.tooltip);
+                    onMouseMoveTooltip(
+                      e,
+                      map,
+                      tooltip,
+                      layer.tooltip,
+                      layer.id,
+                    );
                   };
 
                   // Create a reference to the mouseleave handler function
@@ -2431,7 +2539,8 @@ HTMLWidgets.widget({
 
           // Remove existing legends only from this specific map container
           const mapContainer = map.getContainer();
-          const existingLegends = mapContainer.querySelectorAll(".mapboxgl-legend");
+          const existingLegends =
+            mapContainer.querySelectorAll(".mapboxgl-legend");
           existingLegends.forEach((legend) => legend.remove());
 
           // Don't remove all legend styles globally - they might belong to other maps
@@ -2446,7 +2555,7 @@ HTMLWidgets.widget({
             const legend = document.createElement("div");
             legend.innerHTML = mapData.legend_html;
             legend.classList.add("mapboxgl-legend");
-            
+
             // Append legend to the correct map container instead of main container
             const mapContainer = map.getContainer();
             mapContainer.appendChild(legend);
@@ -2760,7 +2869,8 @@ HTMLWidgets.widget({
                 if (!drawOptions.modes) {
                   drawOptions.modes = Object.assign({}, MapboxDraw.modes);
                 }
-                drawOptions.modes.draw_rectangle = MapboxDraw.modes.draw_rectangle;
+                drawOptions.modes.draw_rectangle =
+                  MapboxDraw.modes.draw_rectangle;
               }
 
               // Add radius mode if enabled
@@ -2780,7 +2890,9 @@ HTMLWidgets.widget({
 
               // Add custom mode buttons and styling
               setTimeout(() => {
-                const drawControlGroup = map.getContainer().querySelector(".mapboxgl-ctrl-group");
+                const drawControlGroup = map
+                  .getContainer()
+                  .querySelector(".mapboxgl-ctrl-group");
 
                 // Add rectangle styling and button
                 if (mapData.draw_control.rectangle) {
@@ -2816,10 +2928,12 @@ HTMLWidgets.widget({
                     rectangleBtn.className = "mapbox-gl-draw_rectangle";
                     rectangleBtn.title = "Rectangle tool";
                     rectangleBtn.type = "button";
-                    rectangleBtn.onclick = function() {
-                      drawControl.changeMode('draw_rectangle');
-                      drawControlGroup.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
-                      rectangleBtn.classList.add('active');
+                    rectangleBtn.onclick = function () {
+                      drawControl.changeMode("draw_rectangle");
+                      drawControlGroup
+                        .querySelectorAll("button")
+                        .forEach((btn) => btn.classList.remove("active"));
+                      rectangleBtn.classList.add("active");
                     };
                     drawControlGroup.appendChild(rectangleBtn);
                   }
@@ -2859,10 +2973,12 @@ HTMLWidgets.widget({
                     radiusBtn.className = "mapbox-gl-draw_radius";
                     radiusBtn.title = "Radius/Circle tool";
                     radiusBtn.type = "button";
-                    radiusBtn.onclick = function() {
-                      drawControl.changeMode('draw_radius');
-                      drawControlGroup.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
-                      radiusBtn.classList.add('active');
+                    radiusBtn.onclick = function () {
+                      drawControl.changeMode("draw_radius");
+                      drawControlGroup
+                        .querySelectorAll("button")
+                        .forEach((btn) => btn.classList.remove("active"));
+                      radiusBtn.classList.add("active");
                     };
                     drawControlGroup.appendChild(radiusBtn);
                   }
@@ -2871,7 +2987,11 @@ HTMLWidgets.widget({
 
               // Add initial features if provided
               if (mapData.draw_control.source) {
-                addSourceFeaturesToDraw(drawControl, mapData.draw_control.source, map);
+                addSourceFeaturesToDraw(
+                  drawControl,
+                  mapData.draw_control.source,
+                  map,
+                );
               }
 
               // Process any queued features
@@ -2898,9 +3018,9 @@ HTMLWidgets.widget({
               // Add download button if requested
               if (mapData.draw_control.download_button) {
                 // Add CSS for download button if not already added
-                if (!document.querySelector('#mapgl-draw-download-styles')) {
-                  const style = document.createElement('style');
-                  style.id = 'mapgl-draw-download-styles';
+                if (!document.querySelector("#mapgl-draw-download-styles")) {
+                  const style = document.createElement("style");
+                  style.id = "mapgl-draw-download-styles";
                   style.textContent = `
                     .mapbox-gl-draw_download {
                       background: transparent;
@@ -2928,38 +3048,48 @@ HTMLWidgets.widget({
                 // Small delay to ensure Draw control is fully rendered
                 setTimeout(() => {
                   // Find the Draw control button group
-                  const drawButtons = map.getContainer().querySelector('.mapboxgl-ctrl-group:has(.mapbox-gl-draw_polygon)');
-                  
+                  const drawButtons = map
+                    .getContainer()
+                    .querySelector(
+                      ".mapboxgl-ctrl-group:has(.mapbox-gl-draw_polygon)",
+                    );
+
                   if (drawButtons) {
                     // Create download button
-                    const downloadBtn = document.createElement('button');
-                    downloadBtn.className = 'mapbox-gl-draw_download';
-                    downloadBtn.title = 'Download drawn features as GeoJSON';
-                    
+                    const downloadBtn = document.createElement("button");
+                    downloadBtn.className = "mapbox-gl-draw_download";
+                    downloadBtn.title = "Download drawn features as GeoJSON";
+
                     // Add SVG download icon
                     downloadBtn.innerHTML = `
                       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                         <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/>
                       </svg>
                     `;
-                    
-                    downloadBtn.addEventListener('click', () => {
+
+                    downloadBtn.addEventListener("click", () => {
                       // Get all drawn features
-                      const data = map._mapgl_draw ? map._mapgl_draw.getAll() : null;
-                      
+                      const data = map._mapgl_draw
+                        ? map._mapgl_draw.getAll()
+                        : null;
+
                       if (data.features.length === 0) {
-                        alert('No features to download. Please draw something first!');
+                        alert(
+                          "No features to download. Please draw something first!",
+                        );
                         return;
                       }
-                      
+
                       // Convert to string with nice formatting
                       const dataStr = JSON.stringify(data, null, 2);
-                      
+
                       // Create blob and download
-                      const blob = new Blob([dataStr], { type: 'application/json' });
+                      const blob = new Blob([dataStr], {
+                        type: "application/json",
+                      });
                       const url = URL.createObjectURL(blob);
-                      
-                      const a = document.createElement('a');
+
+                      const a = document.createElement("a");
                       a.href = url;
                       a.download = `${mapData.draw_control.download_filename}.geojson`;
                       document.body.appendChild(a);
@@ -2967,7 +3097,7 @@ HTMLWidgets.widget({
                       document.body.removeChild(a);
                       URL.revokeObjectURL(url);
                     });
-                    
+
                     // Append to the Draw control button group
                     drawButtons.appendChild(downloadBtn);
                   }
@@ -2978,7 +3108,9 @@ HTMLWidgets.widget({
             // Helper function for updating drawn features
             function updateDrawnFeatures() {
               if (HTMLWidgets.shinyMode && map._mapgl_draw) {
-                const features = map._mapgl_draw ? map._mapgl_draw.getAll() : null;
+                const features = map._mapgl_draw
+                  ? map._mapgl_draw.getAll()
+                  : null;
                 Shiny.setInputValue(
                   el.id + "_drawn_features",
                   JSON.stringify(features),
@@ -3067,17 +3199,25 @@ HTMLWidgets.widget({
             // Set the position correctly - fix position bug by using correct CSS positioning
             const position = mapData.layers_control.position || "top-left";
             if (position === "top-left") {
-              layersControl.style.top = (mapData.layers_control.margin_top || 10) + "px";
-              layersControl.style.left = (mapData.layers_control.margin_left || 10) + "px";
+              layersControl.style.top =
+                (mapData.layers_control.margin_top || 10) + "px";
+              layersControl.style.left =
+                (mapData.layers_control.margin_left || 10) + "px";
             } else if (position === "top-right") {
-              layersControl.style.top = (mapData.layers_control.margin_top || 10) + "px";
-              layersControl.style.right = (mapData.layers_control.margin_right || 10) + "px";
+              layersControl.style.top =
+                (mapData.layers_control.margin_top || 10) + "px";
+              layersControl.style.right =
+                (mapData.layers_control.margin_right || 10) + "px";
             } else if (position === "bottom-left") {
-              layersControl.style.bottom = (mapData.layers_control.margin_bottom || 30) + "px";
-              layersControl.style.left = (mapData.layers_control.margin_left || 10) + "px";
+              layersControl.style.bottom =
+                (mapData.layers_control.margin_bottom || 30) + "px";
+              layersControl.style.left =
+                (mapData.layers_control.margin_left || 10) + "px";
             } else if (position === "bottom-right") {
-              layersControl.style.bottom = (mapData.layers_control.margin_bottom || 40) + "px";
-              layersControl.style.right = (mapData.layers_control.margin_right || 10) + "px";
+              layersControl.style.bottom =
+                (mapData.layers_control.margin_bottom || 40) + "px";
+              layersControl.style.right =
+                (mapData.layers_control.margin_right || 10) + "px";
             }
 
             el.appendChild(layersControl);
@@ -3097,7 +3237,9 @@ HTMLWidgets.widget({
               layersConfig.forEach((config, index) => {
                 const link = document.createElement("a");
                 // Ensure config.ids is always an array
-                const layerIds = Array.isArray(config.ids) ? config.ids : [config.ids];
+                const layerIds = Array.isArray(config.ids)
+                  ? config.ids
+                  : [config.ids];
                 link.id = layerIds.join("-");
                 link.href = "#";
                 link.textContent = config.label;
@@ -3117,7 +3259,9 @@ HTMLWidgets.widget({
                   e.preventDefault();
                   e.stopPropagation();
 
-                  const layerIds = JSON.parse(this.getAttribute("data-layer-ids"));
+                  const layerIds = JSON.parse(
+                    this.getAttribute("data-layer-ids"),
+                  );
                   const firstLayerId = layerIds[0];
                   const visibility = map.getLayoutProperty(
                     firstLayerId,
@@ -3126,12 +3270,12 @@ HTMLWidgets.widget({
 
                   // Toggle visibility for all layer IDs in the group
                   if (visibility === "visible") {
-                    layerIds.forEach(layerId => {
+                    layerIds.forEach((layerId) => {
                       map.setLayoutProperty(layerId, "visibility", "none");
                     });
                     this.className = "";
                   } else {
-                    layerIds.forEach(layerId => {
+                    layerIds.forEach((layerId) => {
                       map.setLayoutProperty(layerId, "visibility", "visible");
                     });
                     this.className = "active";
@@ -3166,7 +3310,11 @@ HTMLWidgets.widget({
                     this.className = "";
                   } else {
                     this.className = "active";
-                    map.setLayoutProperty(clickedLayer, "visibility", "visible");
+                    map.setLayoutProperty(
+                      clickedLayer,
+                      "visibility",
+                      "visible",
+                    );
                   }
                 };
 

--- a/inst/htmlwidgets/maplibregl.js
+++ b/inst/htmlwidgets/maplibregl.js
@@ -1,8 +1,8 @@
 // Measurement functionality
 function createMeasurementBox(map) {
-  const box = document.createElement('div');
+  const box = document.createElement("div");
   box.id = `measurement-box-${map._container.id}`;
-  box.className = 'mapgl-measurement-box';
+  box.className = "mapgl-measurement-box";
   box.style.cssText = `
     position: absolute;
     bottom: 45px;
@@ -37,43 +37,47 @@ function createMeasurementBox(map) {
 
 function calculateDrawingMeasurements(mode, state, coords) {
   try {
-    if (mode === 'draw_line_string' && coords && coords.length >= 2) {
+    if (mode === "draw_line_string" && coords && coords.length >= 2) {
       const line = turf.lineString(coords);
-      const distance = turf.length(line, {units: 'kilometers'});
-      return { type: 'distance', value: distance };
-    }
-
-    else if ((mode === 'draw_polygon' || mode === 'draw_freehand') && coords && coords.length >= 3) {
+      const distance = turf.length(line, { units: "kilometers" });
+      return { type: "distance", value: distance };
+    } else if (
+      (mode === "draw_polygon" || mode === "draw_freehand") &&
+      coords &&
+      coords.length >= 3
+    ) {
       // Ensure polygon is closed by adding first point at end if needed
       const closedCoords = [...coords];
-      if (closedCoords[0][0] !== closedCoords[closedCoords.length - 1][0] ||
-          closedCoords[0][1] !== closedCoords[closedCoords.length - 1][1]) {
+      if (
+        closedCoords[0][0] !== closedCoords[closedCoords.length - 1][0] ||
+        closedCoords[0][1] !== closedCoords[closedCoords.length - 1][1]
+      ) {
         closedCoords.push(closedCoords[0]);
       }
 
       try {
         const polygon = turf.polygon([closedCoords]);
         const area = turf.area(polygon) / 1000000; // Convert to km²
-        const perimeter = turf.length(turf.polygonToLine(polygon), {units: 'kilometers'});
-        return { type: 'area', value: area, perimeter: perimeter };
+        const perimeter = turf.length(turf.polygonToLine(polygon), {
+          units: "kilometers",
+        });
+        return { type: "area", value: area, perimeter: perimeter };
       } catch (error) {
         return null;
       }
-    }
-
-    else if (mode === 'draw_rectangle' && coords && coords.length >= 4) {
+    } else if (mode === "draw_rectangle" && coords && coords.length >= 4) {
       const polygon = turf.polygon([coords]);
       const area = turf.area(polygon) / 1000000; // Convert to km²
-      const perimeter = turf.length(turf.polygonToLine(polygon), {units: 'kilometers'});
-      return { type: 'area', value: area, perimeter: perimeter };
-    }
-
-    else if (mode === 'draw_radius' && coords && coords.length >= 2) {
+      const perimeter = turf.length(turf.polygonToLine(polygon), {
+        units: "kilometers",
+      });
+      return { type: "area", value: area, perimeter: perimeter };
+    } else if (mode === "draw_radius" && coords && coords.length >= 2) {
       const center = turf.point(coords[0]);
       const edge = turf.point(coords[1]);
-      const radius = turf.distance(center, edge, {units: 'kilometers'});
+      const radius = turf.distance(center, edge, { units: "kilometers" });
       const area = Math.PI * radius * radius; // πr²
-      return { type: 'radius', value: radius, area: area };
+      return { type: "radius", value: radius, area: area };
     }
   } catch (e) {
     return null;
@@ -83,12 +87,12 @@ function calculateDrawingMeasurements(mode, state, coords) {
 }
 
 function formatMeasurements(measurements, units) {
-  if (!measurements) return { primary: '', secondary: '' };
+  if (!measurements) return { primary: "", secondary: "" };
 
-  const formatDistance = function(km) {
+  const formatDistance = function (km) {
     let result = [];
 
-    if (units === 'metric' || units === 'both') {
+    if (units === "metric" || units === "both") {
       if (km < 1) {
         result.push(`${(km * 1000).toFixed(0)} m`);
       } else {
@@ -96,7 +100,7 @@ function formatMeasurements(measurements, units) {
       }
     }
 
-    if (units === 'imperial' || units === 'both') {
+    if (units === "imperial" || units === "both") {
       const miles = km * 0.621371;
       if (miles < 0.1) {
         result.push(`${(miles * 5280).toFixed(0)} ft`);
@@ -108,10 +112,10 @@ function formatMeasurements(measurements, units) {
     return result;
   };
 
-  const formatArea = function(sqKm) {
+  const formatArea = function (sqKm) {
     let result = [];
 
-    if (units === 'metric' || units === 'both') {
+    if (units === "metric" || units === "both") {
       if (sqKm < 0.01) {
         result.push(`${(sqKm * 1000000).toFixed(0)} m²`);
       } else if (sqKm < 1) {
@@ -121,7 +125,7 @@ function formatMeasurements(measurements, units) {
       }
     }
 
-    if (units === 'imperial' || units === 'both') {
+    if (units === "imperial" || units === "both") {
       const sqMiles = sqKm * 0.386102;
       if (sqMiles < 0.001) {
         result.push(`${(sqMiles * 640).toFixed(2)} acres`);
@@ -133,83 +137,93 @@ function formatMeasurements(measurements, units) {
     return result;
   };
 
-  if (measurements.type === 'distance') {
+  if (measurements.type === "distance") {
     const formatted = formatDistance(measurements.value);
     return {
-      primary: formatted[0] || '',
-      secondary: formatted[1] || ''
+      primary: formatted[0] || "",
+      secondary: formatted[1] || "",
     };
-  }
-
-  else if (measurements.type === 'area') {
+  } else if (measurements.type === "area") {
     const areaFormatted = formatArea(measurements.value);
     const perimeterFormatted = formatDistance(measurements.perimeter);
 
-    if (units === 'both') {
+    if (units === "both") {
       return {
-        primary: areaFormatted[0] || '',
-        secondary: `${areaFormatted[1] || ''} • ${perimeterFormatted[0] || ''}`
+        primary: areaFormatted[0] || "",
+        secondary: `${areaFormatted[1] || ""} • ${perimeterFormatted[0] || ""}`,
       };
     } else {
       return {
-        primary: areaFormatted[0] || '',
-        secondary: `Perimeter: ${perimeterFormatted[0] || ''}`
+        primary: areaFormatted[0] || "",
+        secondary: `Perimeter: ${perimeterFormatted[0] || ""}`,
       };
     }
-  }
-
-  else if (measurements.type === 'radius') {
+  } else if (measurements.type === "radius") {
     const distFormatted = formatDistance(measurements.value);
     const areaFormatted = formatArea(measurements.area);
 
     return {
-      primary: `Radius: ${distFormatted[0] || ''}`,
-      secondary: units === 'both' ?
-        `${distFormatted[1] || ''} • ${areaFormatted[0] || ''}` :
-        `Area: ${areaFormatted[0] || ''}`
+      primary: `Radius: ${distFormatted[0] || ""}`,
+      secondary:
+        units === "both"
+          ? `${distFormatted[1] || ""} • ${areaFormatted[0] || ""}`
+          : `Area: ${areaFormatted[0] || ""}`,
     };
   }
 
-  return { primary: '', secondary: '' };
+  return { primary: "", secondary: "" };
 }
 
 function updateMeasurementDisplay(box, measurements, units) {
-  const primary = box.querySelector('#measurement-primary');
-  const secondary = box.querySelector('#measurement-secondary');
+  const primary = box.querySelector("#measurement-primary");
+  const secondary = box.querySelector("#measurement-secondary");
 
   const formatted = formatMeasurements(measurements, units);
 
   if (formatted.primary) {
     primary.textContent = formatted.primary;
     secondary.textContent = formatted.secondary;
-    box.style.display = 'block';
+    box.style.display = "block";
   } else {
-    box.style.display = 'none';
+    box.style.display = "none";
   }
 }
 
 function initializeMeasurements(map, draw, units) {
   const measurementBox = createMeasurementBox(map);
-  const DRAWING_MODES = ['draw_line_string', 'draw_polygon', 'draw_rectangle', 'draw_radius', 'draw_freehand'];
+  const DRAWING_MODES = [
+    "draw_line_string",
+    "draw_polygon",
+    "draw_rectangle",
+    "draw_radius",
+    "draw_freehand",
+  ];
 
   // Store original handlers
   const originalHandlers = {};
 
-  DRAWING_MODES.forEach(mode => {
+  DRAWING_MODES.forEach((mode) => {
     const modeObj = MapboxDraw.modes[mode];
     if (!modeObj) return;
 
-
     // Wrap onClick for polygon mode (better for click-based drawing)
-    if (modeObj.onClick && mode === 'draw_polygon') {
-      originalHandlers[mode + '_onClick'] = modeObj.onClick;
-      modeObj.onClick = function(state, e) {
-        const result = originalHandlers[mode + '_onClick'].call(this, state, e);
+    if (modeObj.onClick && mode === "draw_polygon") {
+      originalHandlers[mode + "_onClick"] = modeObj.onClick;
+      modeObj.onClick = function (state, e) {
+        const result = originalHandlers[mode + "_onClick"].call(this, state, e);
 
         // For polygon mode, show measurements after each click
-        if (state.polygon && state.polygon.coordinates && state.polygon.coordinates[0].length >= 3) {
+        if (
+          state.polygon &&
+          state.polygon.coordinates &&
+          state.polygon.coordinates[0].length >= 3
+        ) {
           const coords = state.polygon.coordinates[0];
-          const measurements = calculateDrawingMeasurements(mode, state, coords);
+          const measurements = calculateDrawingMeasurements(
+            mode,
+            state,
+            coords,
+          );
           updateMeasurementDisplay(measurementBox, measurements, units);
         }
 
@@ -218,10 +232,10 @@ function initializeMeasurements(map, draw, units) {
     }
 
     // Wrap onMouseMove for real-time updates (lines, rectangles, radius)
-    if (modeObj.onMouseMove && mode !== 'draw_polygon') {
-      originalHandlers[mode + '_onMouseMove'] = modeObj.onMouseMove;
-      modeObj.onMouseMove = function(state, e) {
-        originalHandlers[mode + '_onMouseMove'].call(this, state, e);
+    if (modeObj.onMouseMove && mode !== "draw_polygon") {
+      originalHandlers[mode + "_onMouseMove"] = modeObj.onMouseMove;
+      modeObj.onMouseMove = function (state, e) {
+        originalHandlers[mode + "_onMouseMove"].call(this, state, e);
 
         let coords = null;
         if (state.line && state.line.coordinates) {
@@ -231,7 +245,11 @@ function initializeMeasurements(map, draw, units) {
         }
 
         if (coords) {
-          const measurements = calculateDrawingMeasurements(mode, state, coords);
+          const measurements = calculateDrawingMeasurements(
+            mode,
+            state,
+            coords,
+          );
           updateMeasurementDisplay(measurementBox, measurements, units);
         }
       };
@@ -239,14 +257,18 @@ function initializeMeasurements(map, draw, units) {
 
     // Wrap onDrag for freehand mode
     if (modeObj.onDrag) {
-      originalHandlers[mode + '_onDrag'] = modeObj.onDrag;
-      modeObj.onDrag = function(state, e) {
-        const result = originalHandlers[mode + '_onDrag'].call(this, state, e);
+      originalHandlers[mode + "_onDrag"] = modeObj.onDrag;
+      modeObj.onDrag = function (state, e) {
+        const result = originalHandlers[mode + "_onDrag"].call(this, state, e);
 
         if (state.polygon && state.polygon.coordinates) {
           const coords = state.polygon.coordinates[0];
           if (coords.length >= 3) {
-            const measurements = calculateDrawingMeasurements(mode, state, coords);
+            const measurements = calculateDrawingMeasurements(
+              mode,
+              state,
+              coords,
+            );
             updateMeasurementDisplay(measurementBox, measurements, units);
           }
         }
@@ -257,74 +279,117 @@ function initializeMeasurements(map, draw, units) {
   });
 
   // Hide measurement box when drawing stops and handle button states
-  map.on('draw.modechange', (e) => {
-    if (e.mode === 'simple_select') {
-      measurementBox.style.display = 'none';
+  map.on("draw.modechange", (e) => {
+    if (e.mode === "simple_select") {
+      measurementBox.style.display = "none";
       // Reset button states when switching to select mode
-      const drawControlGroup = map.getContainer().querySelector(".maplibregl-ctrl-group");
+      const drawControlGroup = map
+        .getContainer()
+        .querySelector(".maplibregl-ctrl-group");
       if (drawControlGroup) {
-        drawControlGroup.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
+        drawControlGroup
+          .querySelectorAll("button")
+          .forEach((btn) => btn.classList.remove("active"));
       }
     }
   });
 
-  map.on('draw.create', () => {
-    measurementBox.style.display = 'none';
+  map.on("draw.create", () => {
+    measurementBox.style.display = "none";
     // Reset button states when drawing is completed
-    const drawControlGroup = map.getContainer().querySelector(".maplibregl-ctrl-group");
+    const drawControlGroup = map
+      .getContainer()
+      .querySelector(".maplibregl-ctrl-group");
     if (drawControlGroup) {
-      drawControlGroup.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
+      drawControlGroup
+        .querySelectorAll("button")
+        .forEach((btn) => btn.classList.remove("active"));
     }
   });
 
-  map.on('draw.delete', () => {
-    measurementBox.style.display = 'none';
+  map.on("draw.delete", () => {
+    measurementBox.style.display = "none";
   });
 
   // Special handling for freehand mode using data update events
-  map.on('draw.update', (e) => {
+  map.on("draw.update", (e) => {
     const currentMode = draw.getMode();
 
-    if (currentMode === 'draw_freehand' && e.features && e.features[0]) {
+    if (currentMode === "draw_freehand" && e.features && e.features[0]) {
       const feature = e.features[0];
-      if (feature.geometry.type === 'Polygon' && feature.geometry.coordinates[0].length >= 3) {
+      if (
+        feature.geometry.type === "Polygon" &&
+        feature.geometry.coordinates[0].length >= 3
+      ) {
         const coords = feature.geometry.coordinates[0];
-        const measurements = calculateDrawingMeasurements('draw_freehand', {}, coords);
+        const measurements = calculateDrawingMeasurements(
+          "draw_freehand",
+          {},
+          coords,
+        );
         updateMeasurementDisplay(measurementBox, measurements, units);
       }
     }
 
     // Also handle editing mode - when features are being edited
-    if (currentMode === 'direct_select' && e.features && e.features[0]) {
+    if (currentMode === "direct_select" && e.features && e.features[0]) {
       const feature = e.features[0];
-      if (feature.geometry.type === 'Polygon' && feature.geometry.coordinates[0].length >= 3) {
+      if (
+        feature.geometry.type === "Polygon" &&
+        feature.geometry.coordinates[0].length >= 3
+      ) {
         const coords = feature.geometry.coordinates[0];
-        const measurements = calculateDrawingMeasurements('draw_polygon', {}, coords);
+        const measurements = calculateDrawingMeasurements(
+          "draw_polygon",
+          {},
+          coords,
+        );
         updateMeasurementDisplay(measurementBox, measurements, units);
-      } else if (feature.geometry.type === 'LineString' && feature.geometry.coordinates.length >= 2) {
+      } else if (
+        feature.geometry.type === "LineString" &&
+        feature.geometry.coordinates.length >= 2
+      ) {
         const coords = feature.geometry.coordinates;
-        const measurements = calculateDrawingMeasurements('draw_line_string', {}, coords);
+        const measurements = calculateDrawingMeasurements(
+          "draw_line_string",
+          {},
+          coords,
+        );
         updateMeasurementDisplay(measurementBox, measurements, units);
       }
     }
   });
 
   // Show measurements when selecting features for editing
-  map.on('draw.selectionchange', (e) => {
+  map.on("draw.selectionchange", (e) => {
     if (e.features && e.features.length > 0) {
       const feature = e.features[0];
-      if (feature.geometry.type === 'Polygon' && feature.geometry.coordinates[0].length >= 3) {
+      if (
+        feature.geometry.type === "Polygon" &&
+        feature.geometry.coordinates[0].length >= 3
+      ) {
         const coords = feature.geometry.coordinates[0];
-        const measurements = calculateDrawingMeasurements('draw_polygon', {}, coords);
+        const measurements = calculateDrawingMeasurements(
+          "draw_polygon",
+          {},
+          coords,
+        );
         updateMeasurementDisplay(measurementBox, measurements, units);
-      } else if (feature.geometry.type === 'LineString' && feature.geometry.coordinates.length >= 2) {
+      } else if (
+        feature.geometry.type === "LineString" &&
+        feature.geometry.coordinates.length >= 2
+      ) {
         const coords = feature.geometry.coordinates;
-        const measurements = calculateDrawingMeasurements('draw_line_string', {}, coords);
+        const measurements = calculateDrawingMeasurements(
+          "draw_line_string",
+          {},
+          coords,
+        );
         updateMeasurementDisplay(measurementBox, measurements, units);
       }
     } else {
       // No features selected, hide measurement box
-      measurementBox.style.display = 'none';
+      measurementBox.style.display = "none";
     }
   });
 }
@@ -391,32 +456,59 @@ function evaluateExpression(expression, properties) {
   }
 }
 
-function onMouseMoveTooltip(e, map, tooltipPopup, tooltipProperty) {
-  map.getCanvas().style.cursor = "pointer";
+function onMouseMoveTooltip(e, map, tooltipPopup, tooltipProperty, layerId) {
   if (e.features.length > 0) {
-    // Clear any existing active tooltip first to prevent stacking
-    if (window._activeTooltip && window._activeTooltip !== tooltipPopup) {
-      window._activeTooltip.remove();
+    // Query all features at this point to determine z-order
+    // Features are returned in top-to-bottom rendering order
+    const allFeatures = map.queryRenderedFeatures(e.point);
+
+    // Find the topmost layer that has a tooltip
+    let topmostLayerWithTooltip = null;
+    for (let i = 0; i < allFeatures.length; i++) {
+      const feature = allFeatures[i];
+      const featureLayerId = feature.layer.id;
+
+      // Check if this layer has a tooltip handler registered
+      if (window._mapboxHandlers && window._mapboxHandlers[featureLayerId]) {
+        topmostLayerWithTooltip = featureLayerId;
+        break;
+      }
     }
 
-    let description;
+    // Only show tooltip if this is the topmost layer with a tooltip
+    if (topmostLayerWithTooltip === layerId) {
+      map.getCanvas().style.cursor = "pointer";
 
-    // Check if tooltipProperty is an expression (array) or a simple property name (string)
-    if (Array.isArray(tooltipProperty)) {
-      // It's an expression, evaluate it
-      description = evaluateExpression(
-        tooltipProperty,
-        e.features[0].properties,
-      );
+      // Clear any existing active tooltip first to prevent stacking
+      if (window._activeTooltip && window._activeTooltip !== tooltipPopup) {
+        window._activeTooltip.remove();
+      }
+
+      let description;
+
+      // Check if tooltipProperty is an expression (array) or a simple property name (string)
+      if (Array.isArray(tooltipProperty)) {
+        // It's an expression, evaluate it
+        description = evaluateExpression(
+          tooltipProperty,
+          e.features[0].properties,
+        );
+      } else {
+        // It's a property name, get the value
+        description = e.features[0].properties[tooltipProperty];
+      }
+
+      tooltipPopup.setLngLat(e.lngLat).setHTML(description).addTo(map);
+
+      // Store reference to currently active tooltip
+      window._activeTooltip = tooltipPopup;
     } else {
-      // It's a property name, get the value
-      description = e.features[0].properties[tooltipProperty];
+      // This layer is not topmost, hide tooltip if it was showing
+      tooltipPopup.remove();
+      if (window._activeTooltip === tooltipPopup) {
+        delete window._activeTooltip;
+      }
     }
-
-    tooltipPopup.setLngLat(e.lngLat).setHTML(description).addTo(map);
-
-    // Store reference to currently active tooltip
-    window._activeTooltip = tooltipPopup;
   } else {
     tooltipPopup.remove();
     // If this was the active tooltip, clear the reference
@@ -435,40 +527,67 @@ function onMouseLeaveTooltip(map, tooltipPopup) {
 }
 
 function onClickPopup(e, map, popupProperty, layerId) {
-  let description;
+  if (e.features.length > 0) {
+    // Query all features at this point to determine z-order
+    const allFeatures = map.queryRenderedFeatures(e.point);
 
-  // Check if popupProperty is an expression (array) or a simple property name (string)
-  if (Array.isArray(popupProperty)) {
-    // It's an expression, evaluate it
-    description = evaluateExpression(popupProperty, e.features[0].properties);
-  } else {
-    // It's a property name, get the value
-    description = e.features[0].properties[popupProperty];
-  }
+    // Find the topmost layer that has a popup
+    let topmostLayerWithPopup = null;
+    for (let i = 0; i < allFeatures.length; i++) {
+      const feature = allFeatures[i];
+      const featureLayerId = feature.layer.id;
 
-  // Remove any existing popup for this layer
-  if (window._mapboxPopups && window._mapboxPopups[layerId]) {
-    window._mapboxPopups[layerId].remove();
-  }
-
-  // Create and show the popup
-  const popup = new maplibregl.Popup({ maxWidth: '400px' })
-    .setLngLat(e.lngLat)
-    .setHTML(description)
-    .addTo(map);
-
-  // Store reference to this popup
-  if (!window._mapboxPopups) {
-    window._mapboxPopups = {};
-  }
-  window._mapboxPopups[layerId] = popup;
-
-  // Remove reference when popup is closed
-  popup.on("close", function () {
-    if (window._mapboxPopups[layerId] === popup) {
-      delete window._mapboxPopups[layerId];
+      // Check if this layer has a popup handler registered
+      if (
+        window._mapboxClickHandlers &&
+        window._mapboxClickHandlers[featureLayerId]
+      ) {
+        topmostLayerWithPopup = featureLayerId;
+        break;
+      }
     }
-  });
+
+    // Only show popup if this is the topmost layer with a popup
+    if (topmostLayerWithPopup === layerId) {
+      let description;
+
+      // Check if popupProperty is an expression (array) or a simple property name (string)
+      if (Array.isArray(popupProperty)) {
+        // It's an expression, evaluate it
+        description = evaluateExpression(
+          popupProperty,
+          e.features[0].properties,
+        );
+      } else {
+        // It's a property name, get the value
+        description = e.features[0].properties[popupProperty];
+      }
+
+      // Remove any existing popup for this layer
+      if (window._mapboxPopups && window._mapboxPopups[layerId]) {
+        window._mapboxPopups[layerId].remove();
+      }
+
+      // Create and show the popup
+      const popup = new maplibregl.Popup({ maxWidth: "400px" })
+        .setLngLat(e.lngLat)
+        .setHTML(description)
+        .addTo(map);
+
+      // Store reference to this popup
+      if (!window._mapboxPopups) {
+        window._mapboxPopups = {};
+      }
+      window._mapboxPopups[layerId] = popup;
+
+      // Remove reference when popup is closed
+      popup.on("close", function () {
+        if (window._mapboxPopups[layerId] === popup) {
+          delete window._mapboxPopups[layerId];
+        }
+      });
+    }
+  }
 }
 
 // Helper function to generate draw styles based on parameters
@@ -720,7 +839,7 @@ HTMLWidgets.widget({
                 mapMarker.setPopup(
                   new maplibregl.Popup({
                     offset: 25,
-                    maxWidth: '400px',
+                    maxWidth: "400px",
                   }).setHTML(marker.popup),
                 );
               }
@@ -770,7 +889,9 @@ HTMLWidgets.widget({
                 }
                 // Add any other additional options
                 for (const [key, value] of Object.entries(source)) {
-                  if (!["id", "type", "url", "tiles", "promoteId"].includes(key)) {
+                  if (
+                    !["id", "type", "url", "tiles", "promoteId"].includes(key)
+                  ) {
                     sourceOptions[key] = value;
                   }
                 }
@@ -913,13 +1034,13 @@ HTMLWidgets.widget({
                 const tooltip = new maplibregl.Popup({
                   closeButton: false,
                   closeOnClick: false,
-                  maxWidth: '400px',
+                  maxWidth: "400px",
                 });
 
                 // Create a reference to the mousemove handler function.
-                // We need to pass 'e', 'map', 'tooltip', and 'layer.tooltip' to onMouseMoveTooltip.
+                // We need to pass 'e', 'map', 'tooltip', 'layer.tooltip', and 'layer.id' to onMouseMoveTooltip.
                 const mouseMoveHandler = function (e) {
-                  onMouseMoveTooltip(e, map, tooltip, layer.tooltip);
+                  onMouseMoveTooltip(e, map, tooltip, layer.tooltip, layer.id);
                 };
 
                 // Create a reference to the mouseleave handler function.
@@ -1332,7 +1453,8 @@ HTMLWidgets.widget({
               if (!drawOptions.modes) {
                 drawOptions.modes = Object.assign({}, MapboxDraw.modes);
               }
-              drawOptions.modes.draw_rectangle = MapboxDraw.modes.draw_rectangle;
+              drawOptions.modes.draw_rectangle =
+                MapboxDraw.modes.draw_rectangle;
             }
 
             // Add radius mode if enabled
@@ -1451,7 +1573,11 @@ HTMLWidgets.widget({
 
             // Add measurement functionality if enabled
             if (x.draw_control.show_measurements) {
-              initializeMeasurements(map, draw, x.draw_control.measurement_units);
+              initializeMeasurements(
+                map,
+                draw,
+                x.draw_control.measurement_units,
+              );
             }
 
             // Add initial features if provided
@@ -1471,22 +1597,28 @@ HTMLWidgets.widget({
 
             // Add custom mode buttons
             setTimeout(() => {
-              const drawControlGroup = map.getContainer().querySelector(".maplibregl-ctrl-group");
+              const drawControlGroup = map
+                .getContainer()
+                .querySelector(".maplibregl-ctrl-group");
 
               if (drawControlGroup) {
                 // Find the trash button to insert before it
-                const trashBtn = drawControlGroup.querySelector('.mapbox-gl-draw_trash');
+                const trashBtn = drawControlGroup.querySelector(
+                  ".mapbox-gl-draw_trash",
+                );
 
                 if (x.draw_control.rectangle) {
                   const rectangleBtn = document.createElement("button");
                   rectangleBtn.className = "mapbox-gl-draw_rectangle";
                   rectangleBtn.title = "Rectangle tool";
                   rectangleBtn.type = "button";
-                  rectangleBtn.onclick = function() {
-                    draw.changeMode('draw_rectangle');
+                  rectangleBtn.onclick = function () {
+                    draw.changeMode("draw_rectangle");
                     // Update active state
-                    drawControlGroup.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
-                    rectangleBtn.classList.add('active');
+                    drawControlGroup
+                      .querySelectorAll("button")
+                      .forEach((btn) => btn.classList.remove("active"));
+                    rectangleBtn.classList.add("active");
                   };
                   // Insert before trash button if it exists, otherwise append
                   if (trashBtn) {
@@ -1501,11 +1633,13 @@ HTMLWidgets.widget({
                   radiusBtn.className = "mapbox-gl-draw_radius";
                   radiusBtn.title = "Radius/Circle tool";
                   radiusBtn.type = "button";
-                  radiusBtn.onclick = function() {
-                    draw.changeMode('draw_radius');
+                  radiusBtn.onclick = function () {
+                    draw.changeMode("draw_radius");
                     // Update active state
-                    drawControlGroup.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
-                    radiusBtn.classList.add('active');
+                    drawControlGroup
+                      .querySelectorAll("button")
+                      .forEach((btn) => btn.classList.remove("active"));
+                    radiusBtn.classList.add("active");
                   };
                   // Insert before trash button if it exists, otherwise append
                   if (trashBtn) {
@@ -2115,11 +2249,12 @@ HTMLWidgets.widget({
             map.on("click", function (e) {
               // Check if draw control is active and in a drawing mode
               let isDrawing = false;
-              if (typeof draw !== 'undefined' && draw) {
+              if (typeof draw !== "undefined" && draw) {
                 const mode = draw.getMode();
-                isDrawing = mode === 'draw_point' ||
-                           mode === 'draw_line_string' ||
-                           mode === 'draw_polygon';
+                isDrawing =
+                  mode === "draw_point" ||
+                  mode === "draw_line_string" ||
+                  mode === "draw_polygon";
               }
 
               // Only process feature clicks if not actively drawing
@@ -2369,12 +2504,18 @@ if (HTMLWidgets.shinyMode) {
             const tooltip = new maplibregl.Popup({
               closeButton: false,
               closeOnClick: false,
-              maxWidth: '400px',
+              maxWidth: "400px",
             });
 
             // Define named handler functions:
             const mouseMoveHandler = function (e) {
-              onMouseMoveTooltip(e, map, tooltip, message.layer.tooltip);
+              onMouseMoveTooltip(
+                e,
+                map,
+                tooltip,
+                message.layer.tooltip,
+                message.layer.id,
+              );
             };
 
             const mouseLeaveHandler = function () {
@@ -3014,7 +3155,7 @@ if (HTMLWidgets.shinyMode) {
                       const tooltip = new maplibregl.Popup({
                         closeButton: false,
                         closeOnClick: false,
-                        maxWidth: '400px',
+                        maxWidth: "400px",
                       });
 
                       // Re-add tooltip handlers
@@ -3205,11 +3346,17 @@ if (HTMLWidgets.shinyMode) {
                   const tooltip = new maplibregl.Popup({
                     closeButton: false,
                     closeOnClick: false,
-                    maxWidth: '400px',
+                    maxWidth: "400px",
                   });
 
                   const mouseMoveHandler = function (e) {
-                    onMouseMoveTooltip(e, map, tooltip, tooltipProperty);
+                    onMouseMoveTooltip(
+                      e,
+                      map,
+                      tooltip,
+                      tooltipProperty,
+                      layerId,
+                    );
                   };
 
                   const mouseLeaveHandler = function () {
@@ -3378,7 +3525,7 @@ if (HTMLWidgets.shinyMode) {
                             const tooltip = new maplibregl.Popup({
                               closeButton: false,
                               closeOnClick: false,
-                              maxWidth: '400px',
+                              maxWidth: "400px",
                             });
 
                             // Re-add tooltip handlers
@@ -3574,7 +3721,7 @@ if (HTMLWidgets.shinyMode) {
                           const tooltip = new maplibregl.Popup({
                             closeButton: false,
                             closeOnClick: false,
-                            maxWidth: '400px',
+                            maxWidth: "400px",
                           });
 
                           const mouseMoveHandler = function (e) {
@@ -3583,6 +3730,7 @@ if (HTMLWidgets.shinyMode) {
                               map,
                               tooltip,
                               tooltipProperty,
+                              layerId,
                             );
                           };
 
@@ -3756,7 +3904,7 @@ if (HTMLWidgets.shinyMode) {
                             const tooltip = new maplibregl.Popup({
                               closeButton: false,
                               closeOnClick: false,
-                              maxWidth: '400px',
+                              maxWidth: "400px",
                             });
 
                             // Re-add tooltip handlers
@@ -3952,7 +4100,7 @@ if (HTMLWidgets.shinyMode) {
                           const tooltip = new maplibregl.Popup({
                             closeButton: false,
                             closeOnClick: false,
-                            maxWidth: '400px',
+                            maxWidth: "400px",
                           });
 
                           const mouseMoveHandler = function (e) {
@@ -3961,6 +4109,7 @@ if (HTMLWidgets.shinyMode) {
                               map,
                               tooltip,
                               tooltipProperty,
+                              layerId,
                             );
                           };
 
@@ -4131,16 +4280,24 @@ if (HTMLWidgets.shinyMode) {
 
         // Add rectangle mode if enabled
         if (message.rectangle) {
-          drawOptions.modes = Object.assign({}, drawOptions.modes || MapboxDraw.modes, {
-            draw_rectangle: MapboxDraw.modes.draw_rectangle,
-          });
+          drawOptions.modes = Object.assign(
+            {},
+            drawOptions.modes || MapboxDraw.modes,
+            {
+              draw_rectangle: MapboxDraw.modes.draw_rectangle,
+            },
+          );
         }
 
         // Add radius mode if enabled
         if (message.radius) {
-          drawOptions.modes = Object.assign({}, drawOptions.modes || MapboxDraw.modes, {
-            draw_radius: MapboxDraw.modes.draw_radius,
-          });
+          drawOptions.modes = Object.assign(
+            {},
+            drawOptions.modes || MapboxDraw.modes,
+            {
+              draw_radius: MapboxDraw.modes.draw_radius,
+            },
+          );
         }
 
         // Create the draw control
@@ -4254,22 +4411,29 @@ if (HTMLWidgets.shinyMode) {
         setTimeout(() => {
           const drawControlGroup = map
             .getContainer()
-            .querySelector(".maplibregl-ctrl-group:has(.mapbox-gl-draw_polygon)");
+            .querySelector(
+              ".maplibregl-ctrl-group:has(.mapbox-gl-draw_polygon)",
+            );
 
           if (drawControlGroup) {
             // Find the trash button to insert before it
-            const trashBtn = drawControlGroup.querySelector('.mapbox-gl-draw_trash');
+            const trashBtn = drawControlGroup.querySelector(
+              ".mapbox-gl-draw_trash",
+            );
 
             if (message.rectangle) {
               const rectangleBtn = document.createElement("button");
-              rectangleBtn.className = "mapbox-gl-draw_rectangle maplibregl-ctrl-icon";
+              rectangleBtn.className =
+                "mapbox-gl-draw_rectangle maplibregl-ctrl-icon";
               rectangleBtn.title = "Rectangle tool";
               rectangleBtn.type = "button";
-              rectangleBtn.onclick = function() {
-                drawControl.changeMode('draw_rectangle');
+              rectangleBtn.onclick = function () {
+                drawControl.changeMode("draw_rectangle");
                 // Remove active class from all buttons and add to this one
-                drawControlGroup.querySelectorAll('button').forEach(b => b.classList.remove('active'));
-                rectangleBtn.classList.add('active');
+                drawControlGroup
+                  .querySelectorAll("button")
+                  .forEach((b) => b.classList.remove("active"));
+                rectangleBtn.classList.add("active");
               };
               // Insert before trash button if it exists, otherwise append
               if (trashBtn) {
@@ -4281,14 +4445,17 @@ if (HTMLWidgets.shinyMode) {
 
             if (message.radius) {
               const radiusBtn = document.createElement("button");
-              radiusBtn.className = "mapbox-gl-draw_radius maplibregl-ctrl-icon";
+              radiusBtn.className =
+                "mapbox-gl-draw_radius maplibregl-ctrl-icon";
               radiusBtn.title = "Radius/Circle tool";
               radiusBtn.type = "button";
-              radiusBtn.onclick = function() {
-                drawControl.changeMode('draw_radius');
+              radiusBtn.onclick = function () {
+                drawControl.changeMode("draw_radius");
                 // Remove active class from all buttons and add to this one
-                drawControlGroup.querySelectorAll('button').forEach(b => b.classList.remove('active'));
-                radiusBtn.classList.add('active');
+                drawControlGroup
+                  .querySelectorAll("button")
+                  .forEach((b) => b.classList.remove("active"));
+                radiusBtn.classList.add("active");
               };
               // Insert before trash button if it exists, otherwise append
               if (trashBtn) {
@@ -4448,7 +4615,9 @@ if (HTMLWidgets.shinyMode) {
 
           if (marker.popup) {
             mapMarker.setPopup(
-              new maplibregl.Popup({ offset: 25, maxWidth: '400px' }).setHTML(marker.popup),
+              new maplibregl.Popup({ offset: 25, maxWidth: "400px" }).setHTML(
+                marker.popup,
+              ),
             );
           }
 
@@ -5101,12 +5270,12 @@ if (HTMLWidgets.shinyMode) {
         const tooltip = new maplibregl.Popup({
           closeButton: false,
           closeOnClick: false,
-          maxWidth: '400px',
+          maxWidth: "400px",
         });
 
         // Define new handlers referencing the updated tooltip property
         const mouseMoveHandler = function (e) {
-          onMouseMoveTooltip(e, map, tooltip, newTooltipProperty);
+          onMouseMoveTooltip(e, map, tooltip, newTooltipProperty, layerId);
         };
         const mouseLeaveHandler = function () {
           onMouseLeaveTooltip(map, tooltip);

--- a/inst/htmlwidgets/maplibregl_compare.js
+++ b/inst/htmlwidgets/maplibregl_compare.js
@@ -60,32 +60,59 @@ function evaluateExpression(expression, properties) {
   }
 }
 
-function onMouseMoveTooltip(e, map, tooltipPopup, tooltipProperty) {
-  map.getCanvas().style.cursor = "pointer";
+function onMouseMoveTooltip(e, map, tooltipPopup, tooltipProperty, layerId) {
   if (e.features.length > 0) {
-    // Clear any existing active tooltip first to prevent stacking
-    if (window._activeTooltip && window._activeTooltip !== tooltipPopup) {
-      window._activeTooltip.remove();
+    // Query all features at this point to determine z-order
+    // Features are returned in top-to-bottom rendering order
+    const allFeatures = map.queryRenderedFeatures(e.point);
+
+    // Find the topmost layer that has a tooltip
+    let topmostLayerWithTooltip = null;
+    for (let i = 0; i < allFeatures.length; i++) {
+      const feature = allFeatures[i];
+      const featureLayerId = feature.layer.id;
+
+      // Check if this layer has a tooltip handler registered
+      if (window._mapboxHandlers && window._mapboxHandlers[featureLayerId]) {
+        topmostLayerWithTooltip = featureLayerId;
+        break;
+      }
     }
 
-    let description;
+    // Only show tooltip if this is the topmost layer with a tooltip
+    if (topmostLayerWithTooltip === layerId) {
+      map.getCanvas().style.cursor = "pointer";
 
-    // Check if tooltipProperty is an expression (array) or a simple property name (string)
-    if (Array.isArray(tooltipProperty)) {
-      // It's an expression, evaluate it
-      description = evaluateExpression(
-        tooltipProperty,
-        e.features[0].properties,
-      );
+      // Clear any existing active tooltip first to prevent stacking
+      if (window._activeTooltip && window._activeTooltip !== tooltipPopup) {
+        window._activeTooltip.remove();
+      }
+
+      let description;
+
+      // Check if tooltipProperty is an expression (array) or a simple property name (string)
+      if (Array.isArray(tooltipProperty)) {
+        // It's an expression, evaluate it
+        description = evaluateExpression(
+          tooltipProperty,
+          e.features[0].properties,
+        );
+      } else {
+        // It's a property name, get the value
+        description = e.features[0].properties[tooltipProperty];
+      }
+
+      tooltipPopup.setLngLat(e.lngLat).setHTML(description).addTo(map);
+
+      // Store reference to currently active tooltip
+      window._activeTooltip = tooltipPopup;
     } else {
-      // It's a property name, get the value
-      description = e.features[0].properties[tooltipProperty];
+      // This layer is not topmost, hide tooltip if it was showing
+      tooltipPopup.remove();
+      if (window._activeTooltip === tooltipPopup) {
+        delete window._activeTooltip;
+      }
     }
-
-    tooltipPopup.setLngLat(e.lngLat).setHTML(description).addTo(map);
-
-    // Store reference to currently active tooltip
-    window._activeTooltip = tooltipPopup;
   } else {
     tooltipPopup.remove();
     // If this was the active tooltip, clear the reference
@@ -104,40 +131,67 @@ function onMouseLeaveTooltip(map, tooltipPopup) {
 }
 
 function onClickPopup(e, map, popupProperty, layerId) {
-  let description;
+  if (e.features.length > 0) {
+    // Query all features at this point to determine z-order
+    const allFeatures = map.queryRenderedFeatures(e.point);
 
-  // Check if popupProperty is an expression (array) or a simple property name (string)
-  if (Array.isArray(popupProperty)) {
-    // It's an expression, evaluate it
-    description = evaluateExpression(popupProperty, e.features[0].properties);
-  } else {
-    // It's a property name, get the value
-    description = e.features[0].properties[popupProperty];
-  }
+    // Find the topmost layer that has a popup
+    let topmostLayerWithPopup = null;
+    for (let i = 0; i < allFeatures.length; i++) {
+      const feature = allFeatures[i];
+      const featureLayerId = feature.layer.id;
 
-  // Remove any existing popup for this layer
-  if (window._maplibrePopups && window._maplibrePopups[layerId]) {
-    window._maplibrePopups[layerId].remove();
-  }
-
-  // Create and show the popup
-  const popup = new maplibregl.Popup({ maxWidth: "400px" })
-    .setLngLat(e.lngLat)
-    .setHTML(description)
-    .addTo(map);
-
-  // Store reference to this popup
-  if (!window._maplibrePopups) {
-    window._maplibrePopups = {};
-  }
-  window._maplibrePopups[layerId] = popup;
-
-  // Remove reference when popup is closed
-  popup.on("close", function () {
-    if (window._maplibrePopups[layerId] === popup) {
-      delete window._maplibrePopups[layerId];
+      // Check if this layer has a popup handler registered
+      if (
+        window._mapboxClickHandlers &&
+        window._mapboxClickHandlers[featureLayerId]
+      ) {
+        topmostLayerWithPopup = featureLayerId;
+        break;
+      }
     }
-  });
+
+    // Only show popup if this is the topmost layer with a popup
+    if (topmostLayerWithPopup === layerId) {
+      let description;
+
+      // Check if popupProperty is an expression (array) or a simple property name (string)
+      if (Array.isArray(popupProperty)) {
+        // It's an expression, evaluate it
+        description = evaluateExpression(
+          popupProperty,
+          e.features[0].properties,
+        );
+      } else {
+        // It's a property name, get the value
+        description = e.features[0].properties[popupProperty];
+      }
+
+      // Remove any existing popup for this layer
+      if (window._maplibrePopups && window._maplibrePopups[layerId]) {
+        window._maplibrePopups[layerId].remove();
+      }
+
+      // Create and show the popup
+      const popup = new maplibregl.Popup({ maxWidth: "400px" })
+        .setLngLat(e.lngLat)
+        .setHTML(description)
+        .addTo(map);
+
+      // Store reference to this popup
+      if (!window._maplibrePopups) {
+        window._maplibrePopups = {};
+      }
+      window._maplibrePopups[layerId] = popup;
+
+      // Remove reference when popup is closed
+      popup.on("close", function () {
+        if (window._maplibrePopups[layerId] === popup) {
+          delete window._maplibrePopups[layerId];
+        }
+      });
+    }
+  }
 }
 
 HTMLWidgets.widget({
@@ -598,6 +652,7 @@ HTMLWidgets.widget({
                         map,
                         tooltip,
                         message.layer.tooltip,
+                        message.layer.id,
                       );
                     };
 
@@ -1353,6 +1408,7 @@ HTMLWidgets.widget({
                               map,
                               tooltip,
                               tooltipProperty,
+                              layerId,
                             );
                           });
 
@@ -2710,27 +2766,65 @@ HTMLWidgets.widget({
             map.controls = [];
           }
           // Define the tooltip handler functions to match the ones in maplibregl.js
-          function onMouseMoveTooltip(e, map, tooltipPopup, tooltipProperty) {
-            map.getCanvas().style.cursor = "pointer";
+          function onMouseMoveTooltip(
+            e,
+            map,
+            tooltipPopup,
+            tooltipProperty,
+            layerId,
+          ) {
             if (e.features.length > 0) {
-              let description;
+              // Query all features at this point to determine z-order
+              const allFeatures = map.queryRenderedFeatures(e.point);
 
-              // Check if tooltipProperty is an expression (array) or a simple property name (string)
-              if (Array.isArray(tooltipProperty)) {
-                // It's an expression, evaluate it
-                description = evaluateExpression(
-                  tooltipProperty,
-                  e.features[0].properties,
-                );
-              } else {
-                // It's a property name, get the value
-                description = e.features[0].properties[tooltipProperty];
+              // Find the topmost layer that has a tooltip
+              let topmostLayerWithTooltip = null;
+              for (let i = 0; i < allFeatures.length; i++) {
+                const feature = allFeatures[i];
+                const featureLayerId = feature.layer.id;
+
+                // Check if this layer has a tooltip handler registered
+                if (
+                  window._mapboxHandlers &&
+                  window._mapboxHandlers[featureLayerId]
+                ) {
+                  topmostLayerWithTooltip = featureLayerId;
+                  break;
+                }
               }
 
-              tooltipPopup.setLngLat(e.lngLat).setHTML(description).addTo(map);
+              // Only show tooltip if this is the topmost layer with a tooltip
+              if (topmostLayerWithTooltip === layerId) {
+                map.getCanvas().style.cursor = "pointer";
 
-              // Store reference to currently active tooltip
-              window._activeTooltip = tooltipPopup;
+                let description;
+
+                // Check if tooltipProperty is an expression (array) or a simple property name (string)
+                if (Array.isArray(tooltipProperty)) {
+                  // It's an expression, evaluate it
+                  description = evaluateExpression(
+                    tooltipProperty,
+                    e.features[0].properties,
+                  );
+                } else {
+                  // It's a property name, get the value
+                  description = e.features[0].properties[tooltipProperty];
+                }
+
+                tooltipPopup
+                  .setLngLat(e.lngLat)
+                  .setHTML(description)
+                  .addTo(map);
+
+                // Store reference to currently active tooltip
+                window._activeTooltip = tooltipPopup;
+              } else {
+                // This layer is not topmost, hide tooltip if it was showing
+                tooltipPopup.remove();
+                if (window._activeTooltip === tooltipPopup) {
+                  delete window._activeTooltip;
+                }
+              }
             } else {
               tooltipPopup.remove();
               // If this was the active tooltip, clear the reference
@@ -3060,7 +3154,13 @@ HTMLWidgets.widget({
 
                   // Create a reference to the mousemove handler function
                   const mouseMoveHandler = function (e) {
-                    onMouseMoveTooltip(e, map, tooltip, layer.tooltip);
+                    onMouseMoveTooltip(
+                      e,
+                      map,
+                      tooltip,
+                      layer.tooltip,
+                      layer.id,
+                    );
                   };
 
                   // Create a reference to the mouseleave handler function


### PR DESCRIPTION
Previously, popups and tooltips on the map were not tied to z-order.  This led to unexpected behavior (popups for one layer showing when they should have shown for another layer) and conflicting / overlapping multiple popups which isn't great behavior.  

This PR fixes #149 and implements intelligent z-order handling for popups / tooltips.  