### PR TITLE
Fix #185

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Imports:
   jsonlite
 Suggests:
   chromote,
+  httpuv,
   knitr,
   mapboxapi,
   usethis,

--- a/R/screenshot.R
+++ b/R/screenshot.R
@@ -75,6 +75,7 @@ save_map <- function(
     delay = NULL
 ) {
   check_installed("chromote", reason = "to render static map screenshots")
+  check_installed("httpuv", reason = "to serve the map HTML over HTTP")
 
   if (!grepl("\\.png$", filename, ignore.case = TRUE)) {
     filename <- paste0(filename, ".png")
@@ -211,7 +212,38 @@ save_map <- function(
     )
   }
 
-  # Launch headless Chrome and capture
+  # Find a free port
+  port <- httpuv::randomPort()
+
+  # Serve the temp directory over HTTP
+  server <- httpuv::startServer(
+    host = "127.0.0.1",
+    port = port,
+    app = list(
+      call = function(req) {
+        if (req$PATH_INFO == "/") {
+          list(
+            status = 302L,
+            headers = list(Location = "/map.html"),
+            body = ""
+          )
+        } else {
+          list(
+            status = 404L,
+            headers = list(),
+            body = "Not found"
+          )
+        }
+      },
+      staticPaths = list(
+        "/" = httpuv::staticPath(tmp_dir, indexhtml = FALSE)
+      )
+    )
+  )
+  on.exit(server$stop(), add = TRUE)
+
+  url <- paste0("http://127.0.0.1:", port, "/map.html")
+
   b <- chromote::ChromoteSession$new(
     width = as.integer(width),
     height = as.integer(height)
@@ -219,7 +251,7 @@ save_map <- function(
   on.exit(b$close(), add = TRUE)
 
   p_load <- b$Page$loadEventFired(wait_ = FALSE)
-  b$Page$navigate(paste0("file://", normalizePath(tmp_html)))
+  b$Page$navigate(url)
   b$wait_for(p_load)
 
   if (use_native_screenshot && !identical(image_scale, 1)) {

--- a/R/screenshot.R
+++ b/R/screenshot.R
@@ -33,8 +33,9 @@
 #' @return The output file path, invisibly.
 #'
 #' @details
-#' This function requires the \pkg{chromote} package and a Chrome or Chromium
-#' browser installation. Install chromote with `install.packages("chromote")`.
+#' This function requires the \pkg{chromote} and \pkg{httpuv} packages.
+#' Install them with `install.packages(c("chromote", "httpuv"))`. \pkg{chromote}
+#' also requires a Chrome or Chromium browser installation.
 #'
 #' The function works by:
 #' 1. Saving the map widget to a temporary HTML file
@@ -212,35 +213,67 @@ save_map <- function(
     )
   }
 
-  # Find a free port
-  port <- httpuv::randomPort()
-
-  # Serve the temp directory over HTTP
-  server <- httpuv::startServer(
-    host = "127.0.0.1",
-    port = port,
-    app = list(
-      call = function(req) {
-        if (req$PATH_INFO == "/") {
-          list(
-            status = 302L,
-            headers = list(Location = "/map.html"),
-            body = ""
-          )
-        } else {
-          list(
-            status = 404L,
-            headers = list(),
-            body = "Not found"
-          )
-        }
-      },
-      staticPaths = list(
-        "/" = httpuv::staticPath(tmp_dir, indexhtml = FALSE)
-      )
+  app <- list(
+    call = function(req) {
+      if (req$PATH_INFO == "/") {
+        list(
+          status = 302L,
+          headers = list(Location = "/map.html"),
+          body = ""
+        )
+      } else {
+        list(
+          status = 404L,
+          headers = list(),
+          body = "Not found"
+        )
+      }
+    },
+    staticPaths = list(
+      "/" = httpuv::staticPath(tmp_dir, indexhtml = FALSE)
     )
   )
-  on.exit(server$stop(), add = TRUE)
+
+  # Start the server with retries to avoid races between randomPort()
+  # and startServer() when multiple processes run in parallel.
+  server <- NULL
+  last_start_error <- NULL
+  max_start_attempts <- 5L
+
+  for (attempt in seq_len(max_start_attempts)) {
+    port <- httpuv::randomPort()
+    server <- tryCatch(
+      httpuv::startServer(
+        host = "127.0.0.1",
+        port = port,
+        app = app
+      ),
+      error = function(err) {
+        last_start_error <<- err
+        NULL
+      }
+    )
+
+    if (!is.null(server)) {
+      break
+    }
+
+    if (attempt < max_start_attempts) {
+      Sys.sleep(0.05)
+    }
+  }
+
+  if (is.null(server)) {
+    stop(
+      sprintf(
+        "Failed to start temporary HTTP server after %d attempts: %s",
+        max_start_attempts,
+        conditionMessage(last_start_error)
+      ),
+      call. = FALSE
+    )
+  }
+  on.exit(try(httpuv::stopServer(server), silent = TRUE), add = TRUE)
 
   url <- paste0("http://127.0.0.1:", port, "/map.html")
 

--- a/man/save_map.Rd
+++ b/man/save_map.Rd
@@ -63,8 +63,9 @@ via the chromote package. Uses the same html2canvas-based screenshot
 infrastructure as \code{\link[=add_screenshot_control]{add_screenshot_control()}}.
 }
 \details{
-This function requires the \pkg{chromote} package and a Chrome or Chromium
-browser installation. Install chromote with \code{install.packages("chromote")}.
+This function requires the \pkg{chromote} and \pkg{httpuv} packages.
+Install them with \code{install.packages(c("chromote", "httpuv"))}. \pkg{chromote}
+also requires a Chrome or Chromium browser installation.
 
 The function works by:
 \enumerate{


### PR DESCRIPTION
Related to:

- https://github.com/walkerke/mapgl/pull/184
- https://github.com/walkerke/mapgl/issues/185

## Problem

`save_map()` was navigating to a `file://` URL to load the temporary HTML widget. On Linux (and in some sandboxed Chrome environments), headless Chrome silently fails to load `file://` URIs, causing `Runtime.evaluate` to time out waiting for the map to initialize (even after Flatpak filesystem overrides).

The error surfaced as:

```
Error:
! Chromote: timed out waiting for response to command Runtime.evaluate
```

## Solution

Replace the `file://` navigation with a temporary local HTTP server using `httpuv`. The server serves the widget's temp directory (including its `_files/` dependencies) over `http://127.0.0.1:<random-port>/map.html`, which Chrome has no restrictions accessing.

Changes in `R/screenshot.R`:

- Add `check_installed("httpuv", ...)` alongside the existing `chromote` check
- Spin up an `httpuv::startServer()` instance bound to a random port via `httpuv::randomPort()`
- Serve the temp widget directory via `staticPaths`, with a `call` handler that redirects `/` to `/map.html`
- Navigate Chromote to the HTTP URL instead of the `file://` path
- Stop the server on exit via `on.exit(server$stop(), add = TRUE)`

## Notes

- `httpuv` is already a transitive dependency of several packages in the Shiny/htmlwidgets ecosystem, so this adds minimal overhead
- The server is bound to localhost only and stopped immediately after the screenshot is taken
- Tested on Linux (Flatpak Chrome) where the original `file://` approach failed consistently