### PR TITLE
Fix #190

### DIFF
--- a/inst/htmlwidgets/screenshot.js
+++ b/inst/htmlwidgets/screenshot.js
@@ -26,6 +26,41 @@ function waitForMapEvent(map, eventName, timeout = 5000, trigger = null) {
   });
 }
 
+function waitForInitialStyleSetup(map, timeout = 10000) {
+  return new Promise(resolve => {
+    if (!map || map._initialStyleLoaded === true) {
+      resolve('ready');
+      return;
+    }
+
+    let settled = false;
+
+    function finish(status) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      clearInterval(poller);
+      map.off('styledata', checkReady);
+      map.off('idle', checkReady);
+      map.off('render', checkReady);
+      resolve(status);
+    }
+
+    function checkReady() {
+      if (map._initialStyleLoaded === true) {
+        finish('ready');
+      }
+    }
+
+    const poller = setInterval(checkReady, 50);
+    const timer = setTimeout(() => finish('timeout'), timeout);
+
+    map.on('styledata', checkReady);
+    map.on('idle', checkReady);
+    map.on('render', checkReady);
+  });
+}
+
 function applyMapScreenshotOptions(map, options) {
   const container = map.getContainer();
   const hiddenElements = [];
@@ -119,11 +154,18 @@ function restoreMapScreenshotOptions(map, state) {
 }
 
 async function prepareMapForScreenshot(map, options) {
-  const state = applyMapScreenshotOptions(map, options);
-
-  // Attribution is always included to comply with map provider TOS
+  let state;
 
   try {
+    // Wait until the widget's initial style setup is complete.
+    // This is important when PMTiles sources are present because source
+    // metadata checks are async and controls may be added later.
+    await waitForInitialStyleSetup(map, 10000);
+
+    state = applyMapScreenshotOptions(map, options);
+
+    // Attribution is always included to comply with map provider TOS
+
     // Wait briefly for the map to settle, but don't block indefinitely.
     // Some Linux/headless browser combinations never report a fully idle map
     // for remote basemap styles even though the canvas is renderable.
@@ -141,7 +183,9 @@ async function prepareMapForScreenshot(map, options) {
 
     return state;
   } catch (error) {
-    restoreMapScreenshotOptions(map, state);
+    if (state) {
+      restoreMapScreenshotOptions(map, state);
+    }
     throw error;
   }
 }


### PR DESCRIPTION
Closes #190

## Problem

- `save_map()` triggers screenshot preparation once the map object is available.
- For PMTiles maps, source-related setup can delay completion of initial style setup.
- Control hiding could occur too early, and controls added shortly after were captured in the final image.

## Changes

- Updated screenshot flow to wait for initial style setup completion before applying screenshot options.
- Added a readiness wait helper in the widget screenshot module.
- Kept timeout safeguards so screenshot calls do not block indefinitely.
- Kept existing restore logic for map state after capture.

## Result

`hide_controls = TRUE` now behaves consistently for:
- maps without PMTiles sources
- maps with PMTiles sources

## Test

```r
library(mapgl)

map <- 
  maplibre(
    bounds = c(-73.99045, -33.75118, -28.84764, 5.271841)
  ) |>
  add_pmtiles_source(
    id = "state_boundaries",
    url = "https://tiles.pmtiles.com.br/geobr/read_state/code-all-year-2020-simplified-TRUE-min_zoom-2-max_zoom-10.pmtiles"
  ) |>
  add_fill_layer(
    id = "fill",
    source = "state_boundaries",
    source_layer = "read_state",
    fill_color = "blue"
  ) |>
  add_navigation_control()

map |>
  save_map(
    filename = "pmtiles_map.png",
    hide_controls = TRUE
  )
```

<img width="900" height="500" alt="pmtiles_map" src="https://github.com/user-attachments/assets/dcd734fe-a412-4228-9b98-0265cf02fbc5" />