### PR TITLE
Fix #192

### DIFF
--- a/R/screenshot.R
+++ b/R/screenshot.R
@@ -9,8 +9,10 @@
 #' @param filename Character string. The output file path. Defaults to
 #'   `"map.png"`. If the filename does not end in `.png`, the extension is
 #'   appended automatically.
-#' @param width Integer. The width of the map viewport in pixels.
-#' @param height Integer. The height of the map viewport in pixels.
+#' @param width Integer. The width of the map viewport in pixels. Always
+#'   overrides any `width` configured when the map widget was created.
+#' @param height Integer. The height of the map viewport in pixels. Always
+#'   overrides any `height` configured when the map widget was created.
 #' @param include_legend Logical. Include the legend in the output? Default
 #'   `TRUE`.
 #' @param hide_controls Logical. Hide navigation and other interactive controls?
@@ -85,6 +87,10 @@ save_map <- function(
     map$x$additional_params <- list()
   }
   map$x$additional_params$preserveDrawingBuffer <- TRUE
+
+  # Always override widget dimensions used by saveWidget()
+  map$width <- as.integer(width) |> paste0("px")
+  map$height <- as.integer(height) |> paste0("px")
 
   # Save widget to temp directory
   tmp_dir <- tempfile("mapgl_")

--- a/man/print_map.Rd
+++ b/man/print_map.Rd
@@ -20,9 +20,11 @@ print_map(
 \arguments{
 \item{map}{A map object created by \code{\link[=mapboxgl]{mapboxgl()}} or \code{\link[=maplibre]{maplibre()}}.}
 
-\item{width}{Integer. The width of the map viewport in pixels.}
+\item{width}{Integer. The width of the map viewport in pixels. Always
+overrides any \code{width} configured when the map widget was created.}
 
-\item{height}{Integer. The height of the map viewport in pixels.}
+\item{height}{Integer. The height of the map viewport in pixels. Always
+overrides any \code{height} configured when the map widget was created.}
 
 \item{include_legend}{Logical. Include the legend in the output? Default
 \code{TRUE}.}

--- a/man/save_map.Rd
+++ b/man/save_map.Rd
@@ -25,9 +25,11 @@ save_map(
 \code{"map.png"}. If the filename does not end in \code{.png}, the extension is
 appended automatically.}
 
-\item{width}{Integer. The width of the map viewport in pixels.}
+\item{width}{Integer. The width of the map viewport in pixels. Always
+overrides any \code{width} configured when the map widget was created.}
 
-\item{height}{Integer. The height of the map viewport in pixels.}
+\item{height}{Integer. The height of the map viewport in pixels. Always
+overrides any \code{height} configured when the map widget was created.}
 
 \item{include_legend}{Logical. Include the legend in the output? Default
 \code{TRUE}.}


### PR DESCRIPTION
Closes #192.

## Changes

- In `save_map()`, explicitly set widget properties before `saveWidget()`.
- Update function documentation to clearly state that `save_map(width, height)` controls export dimensions.

## Test

```r
library(geobr)
library(mapgl)

brazil_shape <- read_country()

map <- 
  brazil_shape |>
  maplibre(
    width = "1000px",
    height = "1000px",
    bounds = _
  ) |>
  add_fill_layer(
    id = "fill",
    source = brazil_shape,
    fill_color = "blue"
  ) |>
  add_navigation_control()

map |>
  save_map(
    width = 1000,
    height = 500,
    hide_controls = TRUE
  )
```

<img width="1000" height="500" alt="pmtiles_map" src="https://github.com/user-attachments/assets/5a02c2a2-83b6-4cb1-a800-0afc7cb99218" />