### PR TITLE
fix #21; support color tables and categorical rasters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mapgl
 Title: Interactive Maps with 'Mapbox GL JS' and 'MapLibre GL JS'
 Version: 0.4.5.9000
-Date: 2026-04-02
+Date: 2026-04-07
 Authors@R:
     person(given = "Kyle", family = "Walker", email = "kyle@walker-data.com", role = c("aut", "cre"))
 Description: Provides an interface to the 'Mapbox GL JS' (<https://docs.mapbox.com/mapbox-gl-js/guides>)

--- a/R/layers.R
+++ b/R/layers.R
@@ -1032,7 +1032,7 @@ add_circle_layer <- function(
 #' @param raster_fade_duration The duration of the fade-in/fade-out effect.
 #' @param raster_hue_rotate Rotates hues around the color wheel.
 #' @param raster_opacity The opacity at which the raster will be drawn.
-#' @param raster_resampling The resampling/interpolation method to use for overscaling.
+#' @param raster_resampling The resampling/interpolation method to use for overscaling. Options are `"linear"` (bilinear, the MapLibre/Mapbox default) and `"nearest"` (nearest-neighbor). Use `"nearest"` for categorical or classified rasters (e.g. land cover) to preserve crisp category boundaries when zooming.
 #' @param raster_saturation Increase or reduce the saturation of the image.
 #' @param visibility Whether this layer is displayed.
 #' @param slot An optional slot for layer order.

--- a/R/sources.R
+++ b/R/sources.R
@@ -344,97 +344,201 @@ add_image_source <- function(
       data <- terra::rast(data)
     }
 
-    if (terra::has.colors(data)) {
-      # If the raster already has a color table
-      rlang::warn(
-        "This function does not support existing color tables, but this feature is in progress."
-      )
-    }
+    is_categorical <- terra::has.colors(data) || terra::is.factor(data)
 
-    # Project to Web Mercator
-    data_mercator <- terra::project(data, "EPSG:3857")
+    if (is_categorical) {
+      # Categorical/color-table raster path
+      # Use nearest-neighbor resampling to preserve category values
 
-    # Get extent in WGS84 for coordinates
-    data_wgs84 <- terra::project(data_mercator, "EPSG:4326")
+      # Capture the original color table before projection
+      orig_ct <- terra::coltab(data)[[1]]
 
-    if (terra::nlyr(data) == 3) {
-      # For RGB raster - write the mercator version to PNG
-      png_path <- tempfile(fileext = ".png")
-      terra::writeRaster(data_mercator, png_path, overwrite = TRUE)
-      url <- base64enc::dataURI(file = png_path, mime = "image/png")
-    } else {
-      # For single band data
-      if (is.null(colors)) {
-        # Get 255 colors for data (0-254), reserving index 255 for NA
-        colors <- grDevices::colorRampPalette(c(
-          "#440154",
-          "#3B528B",
-          "#21908C",
-          "#5DC863",
-          "#FDE725"
-        ))(255)
-      } else if (length(colors) >= 255) {
-        # Use first 255 colors if more provided
-        colors <- colors[1:255]
-      } else {
-        # Interpolate to 255 colors
-        colors <- grDevices::colorRampPalette(colors)(255)
+      if (is.null(orig_ct) || nrow(orig_ct) == 0) {
+        # Factor raster without a color table - generate qualitative colors
+        cat_values <- sort(unique(
+          as.integer(terra::values(data)[!is.na(terra::values(data))])
+        ))
+        n_cats <- length(cat_values)
+        qual_colors <- grDevices::hcl.colors(n_cats, palette = "Set 2")
+        rgb_vals <- grDevices::col2rgb(qual_colors, alpha = TRUE)
+        orig_ct <- data.frame(
+          value = cat_values,
+          red = as.integer(rgb_vals["red", ]),
+          green = as.integer(rgb_vals["green", ]),
+          blue = as.integer(rgb_vals["blue", ]),
+          alpha = as.integer(rgb_vals["alpha", ])
+        )
       }
 
-      # Extract values
-      values <- terra::values(data_mercator)
+      # Project with nearest-neighbor to preserve category values
+      data_mercator <- terra::project(data, "EPSG:3857", method = "near")
 
-      # Handle NA values
-      na_mask <- is.na(values)
+      # Get extent in WGS84 for coordinates
+      data_wgs84 <- terra::project(data_mercator, "EPSG:4326")
 
-      # Rescale to 0-254 range
-      if (all(is.na(values))) {
-        # Handle the case where all values are NA
-        scaled_values <- values # Keep all as NA
-      } else {
-        # Get min/max excluding NAs
-        min_val <- min(values, na.rm = TRUE)
-        max_val <- max(values, na.rm = TRUE)
+      # Render categorical raster to RGBA image using color table
+      # (terra writeRaster produces grayscale PNGs even with coltab)
+      nr <- terra::nrow(data_mercator)
+      nc <- terra::ncol(data_mercator)
+      vals <- as.integer(terra::values(data_mercator))
 
-        if (min_val == max_val) {
-          # Handle case where all non-NA values are the same
-          scaled_values <- values
-          scaled_values[!na_mask] <- 127 # Middle value
-        } else {
-          # Normal rescaling
-          scaled_values <- (values - min_val) / (max_val - min_val) * 254
+      # Build RGBA lookup table from color table (index 0 = transparent for NA)
+      lut_r <- rep(0, 256)
+      lut_g <- rep(0, 256)
+      lut_b <- rep(0, 256)
+      lut_a <- rep(0, 256) # default transparent
+
+      for (i in seq_len(nrow(orig_ct))) {
+        idx <- orig_ct$value[i] + 1L # 0-based value to 1-based index
+        if (idx >= 1L && idx <= 256L) {
+          lut_r[idx] <- orig_ct$red[i]
+          lut_g[idx] <- orig_ct$green[i]
+          lut_b[idx] <- orig_ct$blue[i]
+          lut_a[idx] <- orig_ct$alpha[i]
         }
       }
 
-      # Round to integers
-      scaled_values <- round(scaled_values)
+      # Map NA to index 0 (transparent)
+      vals[is.na(vals)] <- 0L
+      idx <- vals + 1L
 
-      # Ensure values are in 0-254 range
-      scaled_values[scaled_values < 0] <- 0
-      scaled_values[scaled_values > 254] <- 254
+      # Handle values > 255 by remapping to sequential indices
+      if (any(idx > 256L, na.rm = TRUE)) {
+        unique_vals <- sort(unique(vals[vals > 0L]))
+        if (length(unique_vals) > 255) {
+          rlang::warn(
+            paste0(
+              "Raster has ", length(unique_vals),
+              " categories, but only 255 can be represented. ",
+              "Extra categories will be dropped."
+            )
+          )
+          unique_vals <- unique_vals[1:255]
+        }
 
-      # Set NA values to 255 (which we'll make transparent)
-      scaled_values[na_mask] <- 255
+        # Build remap: original value -> new 1-based index
+        val_map <- stats::setNames(seq_along(unique_vals), as.character(unique_vals))
 
-      # Update the raster
-      terra::values(data_mercator) <- scaled_values
+        # Rebuild lookup from original color table with new indices
+        lut_r <- rep(0, 256)
+        lut_g <- rep(0, 256)
+        lut_b <- rep(0, 256)
+        lut_a <- rep(0, 256)
 
-      # Create color table (255 colors + transparent for NA)
-      transparent_color <- "#00000000" # Fully transparent
-      coltb <- data.frame(value = 0:255, col = c(colors, transparent_color))
+        for (i in seq_along(unique_vals)) {
+          ct_row <- match(unique_vals[i], orig_ct$value)
+          if (!is.na(ct_row)) {
+            lut_r[i + 1L] <- orig_ct$red[ct_row]
+            lut_g[i + 1L] <- orig_ct$green[ct_row]
+            lut_b[i + 1L] <- orig_ct$blue[ct_row]
+            lut_a[i + 1L] <- orig_ct$alpha[ct_row]
+          }
+        }
 
-      # Apply color table
-      terra::coltab(data_mercator) <- coltb
+        # Remap pixel values
+        new_vals <- val_map[as.character(vals)]
+        new_vals[is.na(new_vals)] <- 0L
+        idx <- as.integer(new_vals) + 1L
+      }
 
-      # Write to PNG with appropriate datatype
+      # Build RGBA image array (values are row-major, array fills column-major)
+      img <- array(0, dim = c(nr, nc, 4))
+      img[, , 1] <- matrix(lut_r[idx] / 255, nrow = nr, ncol = nc, byrow = TRUE)
+      img[, , 2] <- matrix(lut_g[idx] / 255, nrow = nr, ncol = nc, byrow = TRUE)
+      img[, , 3] <- matrix(lut_b[idx] / 255, nrow = nr, ncol = nc, byrow = TRUE)
+      img[, , 4] <- matrix(lut_a[idx] / 255, nrow = nr, ncol = nc, byrow = TRUE)
+
       png_path <- tempfile(fileext = ".png")
-      terra::writeRaster(
-        data_mercator,
-        png_path,
-        overwrite = TRUE,
-        datatype = "INT1U"
-      )
+      png::writePNG(img, png_path)
       url <- base64enc::dataURI(file = png_path, mime = "image/png")
+    } else {
+      # Continuous / non-categorical raster path
+
+      # Project to Web Mercator
+      data_mercator <- terra::project(data, "EPSG:3857")
+
+      # Get extent in WGS84 for coordinates
+      data_wgs84 <- terra::project(data_mercator, "EPSG:4326")
+
+      if (terra::nlyr(data) == 3) {
+        # For RGB raster - write the mercator version to PNG
+        png_path <- tempfile(fileext = ".png")
+        terra::writeRaster(data_mercator, png_path, overwrite = TRUE)
+        url <- base64enc::dataURI(file = png_path, mime = "image/png")
+      } else {
+        # For single band continuous data
+        if (is.null(colors)) {
+          # Get 255 colors for data (0-254), reserving index 255 for NA
+          colors <- grDevices::colorRampPalette(c(
+            "#440154",
+            "#3B528B",
+            "#21908C",
+            "#5DC863",
+            "#FDE725"
+          ))(255)
+        } else if (length(colors) >= 255) {
+          # Use first 255 colors if more provided
+          colors <- colors[1:255]
+        } else {
+          # Interpolate to 255 colors
+          colors <- grDevices::colorRampPalette(colors)(255)
+        }
+
+        # Extract values
+        values <- terra::values(data_mercator)
+
+        # Handle NA values
+        na_mask <- is.na(values)
+
+        # Rescale to 0-254 range
+        if (all(is.na(values))) {
+          # Handle the case where all values are NA
+          scaled_values <- values # Keep all as NA
+        } else {
+          # Get min/max excluding NAs
+          min_val <- min(values, na.rm = TRUE)
+          max_val <- max(values, na.rm = TRUE)
+
+          if (min_val == max_val) {
+            # Handle case where all non-NA values are the same
+            scaled_values <- values
+            scaled_values[!na_mask] <- 127 # Middle value
+          } else {
+            # Normal rescaling
+            scaled_values <- (values - min_val) / (max_val - min_val) * 254
+          }
+        }
+
+        # Round to integers
+        scaled_values <- round(scaled_values)
+
+        # Ensure values are in 0-254 range
+        scaled_values[scaled_values < 0] <- 0
+        scaled_values[scaled_values > 254] <- 254
+
+        # Set NA values to 255 (which we'll make transparent)
+        scaled_values[na_mask] <- 255
+
+        # Update the raster
+        terra::values(data_mercator) <- scaled_values
+
+        # Create color table (255 colors + transparent for NA)
+        transparent_color <- "#00000000" # Fully transparent
+        coltb <- data.frame(value = 0:255, col = c(colors, transparent_color))
+
+        # Apply color table
+        terra::coltab(data_mercator) <- coltb
+
+        # Write to PNG with appropriate datatype
+        png_path <- tempfile(fileext = ".png")
+        terra::writeRaster(
+          data_mercator,
+          png_path,
+          overwrite = TRUE,
+          datatype = "INT1U"
+        )
+        url <- base64enc::dataURI(file = png_path, mime = "image/png")
+      }
     }
 
     # Compute coordinates from the WGS84 version


### PR DESCRIPTION
Pre-defined terra color tables & categorical rasters are now supported.  Wanted this one for a while!

Closes #21.  