### PR TITLE
Fix stuck timeline brush when window collapses at the right edge

### DIFF
--- a/inst/htmlwidgets/lib/slider/slider.js
+++ b/inst/htmlwidgets/lib/slider/slider.js
@@ -764,7 +764,18 @@
             if (mode === "resize-start") {
                 self._setStart(idxAt(e.clientX), { pause: true });
             } else if (mode === "resize-end") {
-                setEndOrCursor(idxAt(e.clientX));
+                var ei = idxAt(e.clientX);
+                if (self._mode === "window" && ei < self._startIndex) {
+                    // Dragged the end grip left past the start. This happens when
+                    // the window has collapsed against the right edge (start ==
+                    // end) and the end grip sits on top: without this the end
+                    // clamps at the start and the window is stuck. Hand off to a
+                    // start-resize so dragging left reopens the window instead.
+                    mode = "resize-start";
+                    self._setStart(ei, { pause: true });
+                } else {
+                    setEndOrCursor(ei);
+                }
             } else if (mode === "pan") {
                 var rect = chart.getBoundingClientRect();
                 var deltaIdx = Math.round(


### PR DESCRIPTION
Fixes a stuck state in the `presentation = "timeline"` slider brush.

When the window is dragged closed against the right edge (start handle collapsed onto the end, e.g. to view only the most recent point), the two grips overlap and the end grip sits on top. Dragging back left then hit `setEnd`'s `end >= start` clamp and did nothing — the only escape was the play button.

Now, when the end grip is dragged left past the start (which only occurs in this collapsed-at-right state), the interaction hands off to a start-resize so dragging left reopens the window. Gated on `mode === "window"` and `ei < startIndex`, so normal resize/pan/play paths are unchanged.

Verified headlessly: collapse to a zero-width window at the right edge, then drag left reopens it; resize-then-play still preserves width; slider tests pass; `node --check` clean.
